### PR TITLE
security: harden runtime file and command boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
           set -euo pipefail
           yarn security:test-scan
           yarn security:test-appx
+          yarn security:test-codeql
 
   windows-appx-boundary:
     name: Windows APPX signing boundary
@@ -154,6 +155,10 @@ jobs:
       - name: Verify password and fingerprint checks
         shell: pwsh
         run: yarn security:test-appx
+
+      - name: Verify cross-platform security boundaries
+        shell: pwsh
+        run: yarn security:test-codeql
 
       - name: Verify the Forge APPX maker boundary
         shell: pwsh

--- a/build-scripts/common/command-boundary.js
+++ b/build-scripts/common/command-boundary.js
@@ -1,54 +1,59 @@
 'use strict'
 
-const path = require('path')
-
-const supportedArchitectures = new Set([
-  'arm',
-  'arm64',
-  'armv7l',
-  'ia32',
-  'mips64el',
-  'universal',
-  'x64'
-])
-const makeScripts = new Map([
-  ['darwin', 'make:dmg'],
-  ['linux', 'make:deb'],
-  ['mas', 'make:dmg'],
-  ['win32', 'make:win']
-])
-
-function validateBuildTarget (arch, platform) {
-  if (!supportedArchitectures.has(arch)) {
-    throw new Error(`Unsupported BUILD_ARCH: ${arch}`)
+function normalizeArchitecture (arch) {
+  switch (arch) {
+    case 'arm': return 'arm'
+    case 'arm64': return 'arm64'
+    case 'armv7l': return 'armv7l'
+    case 'ia32': return 'ia32'
+    case 'mips64el': return 'mips64el'
+    case 'universal': return 'universal'
+    case 'x64': return 'x64'
+    default: throw new Error(`Unsupported BUILD_ARCH: ${arch}`)
   }
-  if (!makeScripts.has(platform)) {
-    throw new Error(`Unsupported BUILD_PLATFORM: ${platform}`)
-  }
-  return { arch, platform }
 }
 
-function createYarnInvocation ({ arch, platform, runtimePlatform, commandInterpreter }) {
-  validateBuildTarget(arch, platform)
-  const script = makeScripts.get(platform)
+function normalizePlatform (platform) {
+  switch (platform) {
+    case 'darwin': return 'darwin'
+    case 'linux': return 'linux'
+    case 'mas': return 'mas'
+    case 'win32': return 'win32'
+    default: throw new Error(`Unsupported BUILD_PLATFORM: ${platform}`)
+  }
+}
+
+function getMakeScript (platform) {
+  switch (platform) {
+    case 'darwin': return 'make:dmg'
+    case 'linux': return 'make:deb'
+    case 'mas': return 'make:dmg'
+    case 'win32': return 'make:win'
+    default: throw new Error(`Unsupported BUILD_PLATFORM: ${platform}`)
+  }
+}
+
+function validateBuildTarget (arch, platform) {
+  return {
+    arch: normalizeArchitecture(arch),
+    platform: normalizePlatform(platform)
+  }
+}
+
+function createYarnInvocation ({ arch, platform, runtimePlatform }) {
+  const target = validateBuildTarget(arch, platform)
+  const script = getMakeScript(target.platform)
   if (runtimePlatform !== 'win32') {
     return {
       command: 'yarn',
-      args: [script, '--arch', arch],
+      args: [script, '--arch', target.arch],
       options: { shell: false }
     }
   }
 
-  const command = commandInterpreter || process.env.ComSpec || 'cmd.exe'
-  if (
-    command !== 'cmd.exe' &&
-    (!path.win32.isAbsolute(command) || path.win32.basename(command).toLowerCase() !== 'cmd.exe')
-  ) {
-    throw new Error('Invalid Windows command interpreter')
-  }
   return {
-    command,
-    args: ['/d', '/s', '/c', 'yarn.cmd', script, '--arch', arch],
+    command: 'C:\\Windows\\System32\\cmd.exe',
+    args: ['/d', '/s', '/c', 'yarn.cmd', script, '--arch', target.arch],
     options: { shell: false, windowsHide: true }
   }
 }
@@ -70,7 +75,5 @@ function createGitRestoreInvocation () {
 module.exports = {
   createGitRestoreInvocation,
   createYarnInvocation,
-  makeScripts,
-  supportedArchitectures,
   validateBuildTarget
 }

--- a/build-scripts/common/command-boundary.js
+++ b/build-scripts/common/command-boundary.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const path = require('path')
+
+const supportedArchitectures = new Set([
+  'arm',
+  'arm64',
+  'armv7l',
+  'ia32',
+  'mips64el',
+  'universal',
+  'x64'
+])
+const makeScripts = new Map([
+  ['darwin', 'make:dmg'],
+  ['linux', 'make:deb'],
+  ['mas', 'make:dmg'],
+  ['win32', 'make:win']
+])
+
+function validateBuildTarget (arch, platform) {
+  if (!supportedArchitectures.has(arch)) {
+    throw new Error(`Unsupported BUILD_ARCH: ${arch}`)
+  }
+  if (!makeScripts.has(platform)) {
+    throw new Error(`Unsupported BUILD_PLATFORM: ${platform}`)
+  }
+  return { arch, platform }
+}
+
+function createYarnInvocation ({ arch, platform, runtimePlatform, commandInterpreter }) {
+  validateBuildTarget(arch, platform)
+  const script = makeScripts.get(platform)
+  if (runtimePlatform !== 'win32') {
+    return {
+      command: 'yarn',
+      args: [script, '--arch', arch],
+      options: { shell: false }
+    }
+  }
+
+  const command = commandInterpreter || process.env.ComSpec || 'cmd.exe'
+  if (
+    command !== 'cmd.exe' &&
+    (!path.win32.isAbsolute(command) || path.win32.basename(command).toLowerCase() !== 'cmd.exe')
+  ) {
+    throw new Error('Invalid Windows command interpreter')
+  }
+  return {
+    command,
+    args: ['/d', '/s', '/c', 'yarn.cmd', script, '--arch', arch],
+    options: { shell: false, windowsHide: true }
+  }
+}
+
+function createGitRestoreInvocation () {
+  return {
+    command: 'git',
+    args: [
+      'restore',
+      '--worktree',
+      '--',
+      'build-scripts/windows/appx/template.xml',
+      'package.json'
+    ],
+    options: { shell: false }
+  }
+}
+
+module.exports = {
+  createGitRestoreInvocation,
+  createYarnInvocation,
+  makeScripts,
+  supportedArchitectures,
+  validateBuildTarget
+}

--- a/build-scripts/common/electron-packager.js
+++ b/build-scripts/common/electron-packager.js
@@ -70,6 +70,26 @@ const pruneNative = (dir = '') => {
     }
   })
 }
+const replaceTextInFile = (filePath, transform, allowMissing = false) => {
+  let fileFd
+  try {
+    const noFollow = fs.constants.O_NOFOLLOW || 0
+    fileFd = fs.openSync(filePath, fs.constants.O_RDWR | noFollow)
+    if (!fs.fstatSync(fileFd).isFile()) {
+      throw new Error(`Expected a regular file: ${filePath}`)
+    }
+    const original = fs.readFileSync(fileFd, 'utf-8')
+    const updated = transform(original)
+    fs.ftruncateSync(fileFd, 0)
+    fs.writeSync(fileFd, updated, 0, 'utf-8')
+    return true
+  } catch (error) {
+    if (allowMissing && error.code === 'ENOENT') return false
+    throw error
+  } finally {
+    if (fileFd !== undefined) fs.closeSync(fileFd)
+  }
+}
 /**
  * @type { import('@types/electron-packager').Options }
  */
@@ -130,13 +150,15 @@ const options = {
       if (fs.existsSync(dest)) removeDir(dest)
       copyRecursive(src, dest)
     })
-    const packageJsonPath = resolve(buildPath, 'package.json')
-    fs.writeFileSync(packageJsonPath, fs.readFileSync(packageJsonPath).toString().replace(/Alphabiz/g, app.displayName))
-    const indexPath = resolve(buildPath, 'index.html')
-    if (fs.existsSync(indexPath)) {
-      const index = fs.readFileSync(indexPath).toString('utf-8')
-      fs.writeFileSync(indexPath, index.replace(/Alphabiz/g, app.displayName))
-    }
+    replaceTextInFile(
+      resolve(buildPath, 'package.json'),
+      contents => contents.replace(/Alphabiz/g, app.displayName)
+    )
+    replaceTextInFile(
+      resolve(buildPath, 'index.html'),
+      contents => contents.replace(/Alphabiz/g, app.displayName),
+      true
+    )
     callback()
   }],
   afterCopy: [(buildPath, electronVersion, platform, arch, callback) => {

--- a/build-scripts/common/make.js
+++ b/build-scripts/common/make.js
@@ -24,9 +24,9 @@ const version = publicVersion || pkgVersion
 console.log(`version: ${version}`)
 
 // const { platform } = process
-const arch = process.env.BUILD_ARCH || process.arch
-const platform = process.env.BUILD_PLATFORM || process.platform
-validateBuildTarget(arch, platform)
+const requestedArch = process.env.BUILD_ARCH || process.arch
+const requestedPlatform = process.env.BUILD_PLATFORM || process.platform
+const { arch, platform } = validateBuildTarget(requestedArch, requestedPlatform)
 
 const unsupportedModules = [
   /**

--- a/build-scripts/common/make.js
+++ b/build-scripts/common/make.js
@@ -1,4 +1,4 @@
-const { exec, execSync } = require('child_process')
+const { execSync, spawn } = require('child_process')
 const { existsSync, copyFileSync, mkdirSync, readFileSync, writeFileSync, unlinkSync, rmSync, cpSync, readdirSync, statSync } = require('fs')
 const { resolve } = require('path')
 const { version: pkgVersion } = require('../../package.json')
@@ -7,6 +7,7 @@ const publicVersion = existsSync(publicVersionPath)
   ? JSON.parse(readFileSync(publicVersionPath, 'utf8')).version
   : pkgVersion
 const { getAppxSigningCertificate } = require('../windows/appx/signing-certificate')
+const { createGitRestoreInvocation, createYarnInvocation, validateBuildTarget } = require('./command-boundary')
 const versionHeader = publicVersion.match(/\d+\.\d+\.\d+/gm)
 const appConfig = require('../../developer/app');
 const productName = appConfig.displayName;
@@ -25,6 +26,7 @@ console.log(`version: ${version}`)
 // const { platform } = process
 const arch = process.env.BUILD_ARCH || process.arch
 const platform = process.env.BUILD_PLATFORM || process.platform
+validateBuildTarget(arch, platform)
 
 const unsupportedModules = [
   /**
@@ -116,11 +118,12 @@ const makeMacUniversal = async () => {
 }
 
 const doMake = async () => {
-  const arg = platform === 'darwin' || platform === 'mas'
-    ? 'make:dmg'
-    : platform === 'win32'
-      ? 'make:win'
-      : 'make:deb'
+  const invocation = createYarnInvocation({
+    arch,
+    platform,
+    runtimePlatform: process.platform
+  })
+  const arg = invocation.args.find(value => value.startsWith('make:'))
   // console.log('make:win')
   console.log(`Make for \x1b[36m${platform}-${arch}\x1b[0m`)
   const packageDir = resolve(__rootdir, `dist/electron/${productName}-${platform}-${arch}`)
@@ -145,7 +148,7 @@ const doMake = async () => {
   // } else await symlinkDir(packageDir, destDir)
   console.log(`Executing: \x1b[32myarn ${arg}\x1b[0m`)
   const prefix = '\x1b[32m  * make \x1b[0m'
-  const res = exec(`yarn ${arg} --arch ${arch}`)
+  const res = spawn(invocation.command, invocation.args, invocation.options)
   res.stdout.on('data', d => {
     // process.stdout.clearLine()
     readline.clearLine(process.stdout, 0)
@@ -159,13 +162,17 @@ const doMake = async () => {
     readline.cursorTo(process.stderr, 0, null)
     process.stderr.write(prefix + e.toString().trim())
   })
+  res.on('error', error => {
+    process.stderr.write(`${prefix}Failed to start Yarn: ${error.message}\n`)
+    process.exit(1)
+  })
   // res.stderr.pipe(process.stderr)
   res.on('exit', code => {
     // process.stdout.clearLine()
     readline.clearLine(process.stdout, 0)
     readline.cursorTo(process.stdout, 0, null)
     process.stdout.write(prefix + 'Exit.\n')
-    process.exit(code)
+    process.exit(code ?? 1)
   })
 }
 
@@ -214,16 +221,21 @@ const doPostmake = () => {
 }
 
 const doReset = () => {
-  const res = exec(`git checkout -- build-scripts/windows/appx/template.xml package.json`)
+  const invocation = createGitRestoreInvocation()
+  const res = spawn(invocation.command, invocation.args, invocation.options)
   res.stdout.on('data', d => {
     process.stdout.write(d.toString().trim())
   })
   res.stderr.on('data', e => {
     process.stderr.write(e.toString().trim())
   })
+  res.on('error', error => {
+    process.stderr.write(`Failed to start Git: ${error.message}\n`)
+    process.exit(1)
+  })
   res.on('exit', code => {
     process.stdout.write('reset build-scripts/windows/appx/template.xml package.json end.\n')
-    process.exit(code)
+    process.exit(code ?? 1)
   })
 }
 

--- a/build-scripts/macos/app/buildEntitlements.js
+++ b/build-scripts/macos/app/buildEntitlements.js
@@ -1,5 +1,4 @@
-const { existsSync, readFileSync, writeFileSync } = require('fs')
-const { tmpdir } = require('os')
+const { lstatSync, readFileSync, realpathSync, writeFileSync } = require('fs')
 const { resolve } = require('path')
 const app = require('../../../developer/app')
 const identifier = app.appIdentifier
@@ -8,7 +7,7 @@ const fullIdentifier = teamId + '.' + identifier
 
 const toReplace = { identifier, teamId, fullIdentifier }
 
-const buildEntitlements = async (dist = '', isPkg = false) => {
+const buildEntitlements = (dist = '', isPkg = false) => {
   const entitlements = ['mas', 'inherit', 'loginhelper']
   if (isPkg) {
     console.log('Is PKG')
@@ -29,15 +28,21 @@ const buildEntitlements = async (dist = '', isPkg = false) => {
         info = info.replace(`{{${key}}}`, toReplace[key])
       }
     }
-    writeFileSync(dest, info, 'utf-8')
+    writeFileSync(dest, info, {
+      encoding: 'utf-8',
+      flag: 'wx',
+      mode: 0o600
+    })
   })
 }
 
-let dist = ''
-if (process.argv[2] && existsSync(process.argv[2])) {
-  dist = process.argv[2]
-} else {
-  console.warn('Warn: dist not be specified or not exists.')
-  dist = resolve(tmpdir(), 'electron-build/entitlements')
+if (!process.argv[2]) {
+  throw new Error('A freshly-created entitlements directory is required')
 }
+const requestedDist = process.argv[2]
+const requestedDistStat = lstatSync(requestedDist)
+if (requestedDistStat.isSymbolicLink() || !requestedDistStat.isDirectory()) {
+  throw new Error('Entitlements output must be a real directory')
+}
+const dist = realpathSync(requestedDist)
 buildEntitlements(dist, process.argv.includes('--pkg'))

--- a/build-scripts/macos/app/sign.sh
+++ b/build-scripts/macos/app/sign.sh
@@ -29,19 +29,30 @@ else
   echo "Warn: Cannot find embedded.provisionprofile in developer folder. This may cause error if you submit signed app to MAS"
 fi
 
-if test -d "$TMPDIR"; then
+if test -n "${TMPDIR:-}" && test -d "$TMPDIR"; then
     :
-elif test -d "$TMP"; then
+elif test -n "${TMP:-}" && test -d "$TMP"; then
     TMPDIR=$TMP
 elif test -d /var/tmp; then
     TMPDIR=/var/tmp
 else
     TMPDIR=/tmp
 fi
-ENTITLEMENTS_DIR="$TMPDIR/electron-build-mas/entitlements"
-mkdir -p "$ENTITLEMENTS_DIR"
+umask 077
+if ! ENTITLEMENTS_DIR=$(mktemp -d "${TMPDIR%/}/alphabiz-entitlements.XXXXXX"); then
+  echo "Error: failed to create a private entitlements directory" >&2
+  exit 1
+fi
+cleanup_entitlements() {
+  rm -rf "$ENTITLEMENTS_DIR"
+}
+trap cleanup_entitlements 0
+trap 'exit 1' HUP INT TERM
 
-TEAM_ID="$APPLE_TEAM_ID" node "build-scripts/macos/app/buildEntitlements.js" "$ENTITLEMENTS_DIR"
+if ! TEAM_ID="$APPLE_TEAM_ID" node "build-scripts/macos/app/buildEntitlements.js" "$ENTITLEMENTS_DIR"; then
+  echo "Error: failed to build entitlements" >&2
+  exit 1
+fi
 
 ENTITLEMENT="$ENTITLEMENTS_DIR/entitlements.mas.plist"
 INHERIT="$ENTITLEMENTS_DIR/entitlements.inherit.plist"

--- a/build-scripts/macos/pkg/sign.sh
+++ b/build-scripts/macos/pkg/sign.sh
@@ -27,19 +27,30 @@ else
   echo "Warn: Cannot find embedded.provisionprofile in developer folder. This may cause error if you submit signed app to MAS"
 fi
 
-if test -d "$TMPDIR"; then
+if test -n "${TMPDIR:-}" && test -d "$TMPDIR"; then
     :
-elif test -d "$TMP"; then
+elif test -n "${TMP:-}" && test -d "$TMP"; then
     TMPDIR=$TMP
 elif test -d /var/tmp; then
     TMPDIR=/var/tmp
 else
     TMPDIR=/tmp
 fi
-ENTITLEMENTS_DIR="$TMPDIR/electron-build-mas/entitlements"
-mkdir -p "$ENTITLEMENTS_DIR"
+umask 077
+if ! ENTITLEMENTS_DIR=$(mktemp -d "${TMPDIR%/}/alphabiz-entitlements.XXXXXX"); then
+  echo "Error: failed to create a private entitlements directory" >&2
+  exit 1
+fi
+cleanup_entitlements() {
+  rm -rf "$ENTITLEMENTS_DIR"
+}
+trap cleanup_entitlements 0
+trap 'exit 1' HUP INT TERM
 
-TEAM_ID="$APPLE_TEAM_ID" node "build-scripts/macos/app/buildEntitlements.js" "$ENTITLEMENTS_DIR" --pkg
+if ! TEAM_ID="$APPLE_TEAM_ID" node "build-scripts/macos/app/buildEntitlements.js" "$ENTITLEMENTS_DIR" --pkg; then
+  echo "Error: failed to build entitlements" >&2
+  exit 1
+fi
 
 # ENTITLEMENT="$ENTITLEMENTS_DIR/entitlements.mas.plist"
 ENTITLEMENT="build-scripts/macos/pkg/entitlements.plist"

--- a/dist/electron/UnPackaged/torrent-file.js
+++ b/dist/electron/UnPackaged/torrent-file.js
@@ -1,0 +1,121 @@
+(() => {
+  'use strict'
+
+  const crypto = require('crypto')
+  const fs = require('fs')
+  const path = require('path')
+
+  const INFO_HASH_PATTERN = /^(?:[a-f\d]{40}|[a-f\d]{64})$/i
+
+  function writeUniqueSibling (filePath, contents) {
+    const parsedPath = path.parse(filePath)
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const suffix = crypto.randomBytes(8).toString('hex')
+      const candidate = path.join(
+        parsedPath.dir,
+        `${parsedPath.name}.${suffix}${parsedPath.ext}`
+      )
+      try {
+        fs.writeFileSync(candidate, contents, { flag: 'wx', mode: 0o600 })
+        return candidate
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error
+      }
+    }
+    throw new Error('Unable to create a unique torrent file')
+  }
+
+  function writeFileOnce (filePath, torrentFile) {
+    const contents = Buffer.from(torrentFile)
+    try {
+      fs.writeFileSync(filePath, contents, { flag: 'wx', mode: 0o600 })
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error
+
+      let existingFd
+      try {
+        const noFollow = fs.constants.O_NOFOLLOW
+        if (!noFollow) {
+          return writeUniqueSibling(filePath, contents)
+        }
+        existingFd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow)
+        if (!fs.fstatSync(existingFd).isFile()) {
+          throw new Error(`Refusing to use a non-regular torrent file: ${filePath}`)
+        }
+        if (!fs.readFileSync(existingFd).equals(contents)) {
+          throw new Error(`Refusing to replace a different torrent file: ${filePath}`)
+        }
+      } finally {
+        if (existingFd !== undefined) fs.closeSync(existingFd)
+      }
+    }
+    return filePath
+  }
+
+  function prepareDirectory (directory) {
+    const resolvedDirectory = path.resolve(directory)
+    fs.mkdirSync(resolvedDirectory, { recursive: true, mode: 0o700 })
+    const realDirectory = fs.realpathSync(resolvedDirectory)
+    if (!fs.statSync(realDirectory).isDirectory()) {
+      throw new Error(`Expected a torrent directory: ${resolvedDirectory}`)
+    }
+    return realDirectory
+  }
+
+  function saveTorrentByInfoHash (directory, infoHash, torrentFile) {
+    const normalizedInfoHash = String(infoHash).toLowerCase()
+    if (!INFO_HASH_PATTERN.test(normalizedInfoHash)) {
+      throw new Error('Invalid torrent info hash')
+    }
+    const resolvedDirectory = prepareDirectory(directory)
+    return writeFileOnce(
+      path.join(resolvedDirectory, `${normalizedInfoHash}.torrent`),
+      torrentFile
+    )
+  }
+
+  function sanitizeTorrentName (name) {
+    let safeName = String(name)
+      .replace(/[\u0000-\u001f\u007f<>:"/\\|?*]/g, '_')
+      .replace(/^\.+/, '_')
+      .replace(/[. ]+$/g, '')
+    if (/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(safeName)) {
+      safeName = `_${safeName}`
+    }
+    let byteLength = 0
+    let truncatedName = ''
+    for (const character of safeName) {
+      const characterBytes = Buffer.byteLength(character, 'utf-8')
+      if (byteLength + characterBytes > 200) break
+      byteLength += characterBytes
+      truncatedName += character
+    }
+    safeName = truncatedName.replace(/[. ]+$/g, '')
+    if (!safeName) throw new Error('Invalid torrent name')
+    return safeName
+  }
+
+  function saveTorrentByName (directory, name, torrentFile) {
+    const resolvedDirectory = prepareDirectory(directory)
+    const torrentPath = path.resolve(
+      resolvedDirectory,
+      `${sanitizeTorrentName(name)}.torrent`
+    )
+    if (path.dirname(torrentPath) !== resolvedDirectory) {
+      throw new Error('Invalid torrent path')
+    }
+    return writeFileOnce(torrentPath, torrentFile)
+  }
+
+  Object.defineProperty(globalThis, 'alphabizTorrentFile', {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: Object.freeze({
+      INFO_HASH_PATTERN,
+      sanitizeTorrentName,
+      saveTorrentByInfoHash,
+      saveTorrentByName
+    })
+  })
+})()

--- a/dist/electron/UnPackaged/webtorrent-preload.js
+++ b/dist/electron/UnPackaged/webtorrent-preload.js
@@ -1,1 +1,310 @@
-const{ipcRenderer:ipcRenderer}=require("electron"),{existsSync:existsSync,writeFileSync:writeFileSync,readFileSync:readFileSync,mkdirSync:mkdirSync,cpSync:cpSync,statSync:statSync,rmSync:rmSync}=require("fs"),{resolve:resolve,dirname:dirname}=require("path"),WebTorrent=require("webtorrent");import utils from"./webtorrent-utils.js";const{torrentToJson:torrentToJson}=utils,downloadThreshold=3e7,maxWaitTime=6e4,maxTask=5;let maxPreload=20;if("string"===typeof localStorage.getItem("library-max-preload")){const e=Number(localStorage.getItem("library-max-preload"));isNaN(e)||(maxPreload=e)}let storePath="";const preloadClient=new WebTorrent({maxConns:5,downloadLimit:3e6,uploadLimit:3e5}),preloadTasks=new Map,taskQueue=[],previous=[],failures=[];global.preload={client:preloadClient,tasks:preloadTasks,queue:taskQueue};const saveTasks=()=>{if(!storePath)return;existsSync(dirname(storePath))||mkdirSync(dirname(storePath),{recursive:!0});const e=[];for(const[r,t]of preloadTasks.entries())e.push({url:r,...t});writeFileSync(storePath,JSON.stringify(e,null,2))},removeOldIfNeeded=()=>{if(!storePath)return;let e=preloadTasks.size-maxPreload;if(!(e<=0))for(const[r,t]of[...preloadTasks.entries()])if(preloadTasks.delete(r),[t.torrentPath,t.downloadPath].forEach((e=>{"string"===typeof e&&existsSync(e)&&rmSync(e,{recursive:!0})})),console.log("[Preload] Remove old task",r),e--,e<=0)return saveTasks()},queueTask=({url:e,path:r,origin:t,postTitle:o})=>{if(maxPreload<=0)return;if(taskQueue.find((r=>r.url===e)))return console.log("[Preload] Skip existed",e);if(taskQueue.length>=maxTask){const e=taskQueue.shift();if(e){const{url:r,path:t,origin:o,postTitle:s,torrent:a}=e;console.log("[Preload] Remove first old task from queue",r),preloadTasks.has(r)?a.destroy((()=>{})):a.destroy({destroyStore:!0},(()=>{previous.push({url:r,path:t,origin:o,postTitle:s})}))}}let s=!1;const a=preloadClient.add(e,{path:r,storeOpts:{postTitle:o||""},postTitle:o,strategy:"sequential"});taskQueue.push({url:e,path:r,origin:t,postTitle:o,torrent:a});const n=setTimeout((()=>{a.ready||a.destroyed||(console.log("[Preload] Failed to load task",t),ipcRenderer.send("preload-failed",t),a.destroy((()=>{const r=taskQueue.findIndex((r=>r.url===e));if(-1!==r){const[e]=taskQueue.splice(r,1);failures.find((r=>r.origin===e.origin))||failures.push(e)}})))}),maxWaitTime);return a.on("ready",(()=>{if(clearTimeout(n),!a.torrentFile||!a.infoHash)return;const o=resolve(dirname(r),`../torrents/${a.infoHash}.torrent`);existsSync(dirname(o))||mkdirSync(dirname(o),{recursive:!0}),existsSync(o)||writeFileSync(o,a.torrentFile),preloadTasks.has(e)||(preloadTasks.set(e,{downloadPath:r,torrentPath:o,origin:t,torrent:Object.assign(torrentToJson(a),{preloadStatus:1})}),saveTasks())})),a.on("download",(()=>{s||a.downloaded>downloadThreshold&&(s=!0,a.destroy((()=>{console.log("[Preload] Finish preloading",t),removeOldIfNeeded(),ipcRenderer.emit("preload-done",t);const r=taskQueue.findIndex((r=>r.url===e)),o=preloadTasks.get(e);if(o&&(o.torrent=Object.assign(torrentToJson(a),{preloadStatus:2}),saveTasks()),-1!==r&&(taskQueue.splice(r,1),taskQueue.length<maxTask&&previous.length)){const{url:e,path:r,origin:t,postTitle:o}=previous.shift();queueTask({url:e,path:r,origin:t,postTitle:o})}})))})),a};ipcRenderer.on("preload-restore",((e,r)=>{console.log("[Preload] Restore",r);try{const e=resolve(r,"preload-tasks.json"),t=new Date;t.setDate(t.getDate()-7);const o=t.valueOf();if(existsSync(e)){const r=JSON.parse(readFileSync(e));for(const e of r){if(!existsSync(e.torrentPath)||!existsSync(e.downloadPath)){existsSync(e.torrentPath)&&rmSync(e.torrentPath),existsSync(e.downloadPath)&&rmSync(e.downloadPath,{recursive:!0});continue}if(e.removed)continue;const{mtimeMs:r}=statSync(e.torrentPath);r<o?(rmSync(e.torrentPath),existsSync(e.downloadPath)&&rmSync(e.downloadPath,{recursive:!0})):e.torrent&&e.torrent.downloaded<downloadThreshold?(queueTask({url:e.url,origin:e.origin,path:e.downloadPath,postTitle:e.torrent.postTitle||e.torrent.name}),console.log("[Preload] Restart",e.url)):(console.log("[Preload] Restore",e.url),preloadTasks.set(e.url,e))}console.log(`[Preload] Restore ${r.length} tasks`)}storePath=e}catch(e){console.log(`Failed to load preloads from ${r}`,e)}})),ipcRenderer.on("preload-task",((e,{url:r,path:t,origin:o,postTitle:s})=>{preloadTasks.has(r)||(console.log("[Preload] Receive task",{url:r,path:t,origin:o,postTitle:s}),queueTask({url:r,path:t,origin:o,postTitle:s}))}));export default{loadCache(e,r){if(preloadTasks.has(e)){const{torrentPath:t,downloadPath:o,removed:s}=preloadTasks.get(e);return s?(console.log("Preload task is removed!"),t):(console.log("copy",o,r),cpSync(o,r,{recursive:!0}),setTimeout((()=>{rmSync(o,{recursive:!0}),preloadTasks.set(e,{torrentPath:t,removed:!0})}),5e3),t)}return null},enable(){maxPreload=40,localStorage.setItem("library-max-preload","40")},disable(){maxPreload=0,localStorage.setItem("library-max-preload","0"),removeOldIfNeeded(),taskQueue.splice(0),preloadTasks.clear()},preloadTasks:preloadTasks,taskQueue:taskQueue,failures:failures};
+const { ipcRenderer } = require('electron')
+const { existsSync, writeFileSync, readFileSync, mkdirSync, cpSync, statSync, rmSync } = require('fs')
+const { resolve, dirname } = require('path')
+const WebTorrent = require('webtorrent')
+const { saveTorrentByInfoHash } = globalThis.alphabizTorrentFile || {}
+if (typeof saveTorrentByInfoHash !== 'function') {
+  throw new Error('Torrent file security boundary is not loaded')
+}
+import utils from './webtorrent-utils.js'
+const { torrentToJson } = utils
+
+/**
+ * @typedef { import('webtorrent/lib/torrent') } Torrent
+ */
+
+// Currently up to download 30MB for a task
+const downloadThreshold = 30_000_000
+// Wait a torrent for 10 mins to ready
+const maxWaitTime = 60_000
+// Only allow downloading `maxTask` tasks at same time
+const maxTask = 5
+
+// If tasks count is larger than this, remove oldest task from disk
+// Set to 0 and call `removeOldIfNeeded` will remove all preload tasks
+let maxPreload = 20
+// Load config from local storage when launched
+if (typeof localStorage.getItem('library-max-preload') === 'string') {
+  const n = Number(localStorage.getItem('library-max-preload'))
+  if (!isNaN(n)) maxPreload = n
+}
+// Store path
+let storePath = ''
+const preloadClient = new WebTorrent({
+  maxConns: 5,
+  downloadLimit: 3000_000,
+  uploadLimit: 300_000
+})
+
+/**
+ * @typedef PreloadTask
+ * @property { string } torrentPath
+ * @property { string } downloadPath
+ * @property { string } origin
+ * @property { Torrent } torrent
+ */
+/** @type { Map<string, PreloadTask> } a map of all added tasks */
+const preloadTasks = new Map()
+/** @type { { url: string, path: string, origin: string, postTitle: string, torrent: Torrent }[] } a queue of current downloading urls */
+const taskQueue = []
+/** @type { { url: string, path: string, origin: string, postTitle: string }[] } */
+const previous = []
+/** @type { { url: string, path: string, origin: string, postTitle: string, torrent: Torrent }[] } a queue of current downloading urls */
+const failures = []
+
+// For debug
+global.preload = {
+  client: preloadClient,
+  tasks: preloadTasks,
+  queue: taskQueue
+}
+// Save preloaded tasks
+const saveTasks = () => {
+  if (!storePath) return
+  if (!existsSync(dirname(storePath))) mkdirSync(dirname(storePath), { recursive: true })
+  const tasks = []
+  for (const [url, task] of preloadTasks.entries()) {
+    tasks.push({
+      url,
+      ...task
+    })
+  }
+  writeFileSync(storePath, JSON.stringify(tasks, null, 2))
+}
+const removeOldIfNeeded = () => {
+  if (!storePath) return
+  let overStack = preloadTasks.size - maxPreload
+  if (overStack <= 0) return
+  // Use [...entries] to avoid errors when we delete entry from map
+  for (const [url, task] of [...preloadTasks.entries()]) {
+    preloadTasks.delete(url)
+    ;[task.torrentPath, task.downloadPath].forEach(p => {
+      if (typeof p === 'string' && existsSync(p)) rmSync(p, { recursive: true })
+    })
+    console.log('[Preload] Remove old task', url)
+    overStack--
+    // Save result
+    if (overStack <= 0) return saveTasks()
+  }
+}
+
+
+/**
+ * @function queueTask
+ * @param { object } conf
+ * @param { string } conf.url magnet url
+ * @param { string } conf.path preload directory
+ * @param { string } conf.origin origin alphabiz-url
+ * @param { string } conf.postTitle post title
+ * @returns { Torrent }
+ */
+const queueTask = ({ url, path, origin, postTitle }) => {
+  if (maxPreload <= 0) return
+  if (taskQueue.find(i => i.url === url)) return console.log('[Preload] Skip existed', url)
+  if (taskQueue.length >= maxTask) {
+    // Destroy oldest one
+    const task = taskQueue.shift()
+    if (task) {
+      const { url, path, origin, postTitle, torrent } = task
+      console.log('[Preload] Remove first old task from queue', url)
+      /**
+       * If torrent is not ready, all downloaded pieces are not able to be reused.
+       * So we have to remove them all for saving disk space.
+       */
+      if (!preloadTasks.has(url)) {
+        torrent.destroy({ destroyStore: true }, () => {
+          // If anyone of other tasks is completed, we can try restore old tasks from here
+          previous.push({ url, path, origin, postTitle })
+        })
+      } else {
+        torrent.destroy(() => {})
+      }
+    }
+  }
+  let destroying = false
+  const torrent = preloadClient.add(url, {
+    path,
+    storeOpts: {
+      postTitle: postTitle || ''
+    },
+    postTitle,
+    strategy: 'sequential'
+  })
+  taskQueue.push({ url, path, origin, postTitle, torrent })
+  const timer = setTimeout(() => {
+    if (!torrent.ready && !torrent.destroyed) {
+      console.log('[Preload] Failed to load task', origin)
+      // The origin ab-url is used to disable download-and-play button in main process
+      ipcRenderer.send('preload-failed', origin)
+      // Torrent is still pending after a long time. Remove it
+      torrent.destroy(() => {
+        const index = taskQueue.findIndex(i => i.url === url)
+        if (index !== -1) {
+          const [task] = taskQueue.splice(index, 1)
+          if (!failures.find(f => f.origin === task.origin)) failures.push(task)
+        }
+      })
+    }
+  }, maxWaitTime)
+  torrent.on('ready', () => {
+    clearTimeout(timer)
+    if (!torrent.torrentFile || !torrent.infoHash) return
+    const torrentsDir = resolve(dirname(path), '../torrents')
+    let torrentPath
+    try {
+      torrentPath = saveTorrentByInfoHash(
+        torrentsDir,
+        torrent.infoHash,
+        torrent.torrentFile
+      )
+    } catch (error) {
+      console.error('[Preload] Refused to save torrent metadata', error)
+      ipcRenderer.send('preload-failed', origin)
+      return
+    }
+    if (!preloadTasks.has(url)) {
+      preloadTasks.set(url, {
+        downloadPath: path,
+        torrentPath,
+        origin,
+        torrent: Object.assign(
+          torrentToJson(torrent),
+          /**
+           * Preload status
+           * (0) - not a preload task
+           * 1 - downloading
+           * 2 - downloaded
+           */
+          { preloadStatus: 1 }
+        )
+      })
+      saveTasks()
+    }
+  })
+  torrent.on('download', () => {
+    if (destroying) return
+    // Avoid trigger twice
+    if (torrent.downloaded > downloadThreshold) {
+      destroying = true
+      torrent.destroy(() => {
+        console.log('[Preload] Finish preloading', origin)
+        removeOldIfNeeded()
+        ipcRenderer.emit('preload-done', origin)
+        const index = taskQueue.findIndex(i => i.url === url)
+        const old = preloadTasks.get(url)
+        if (old) {
+          // Only update preload status after downloaded
+          old.torrent = Object.assign(
+            torrentToJson(torrent),
+            { preloadStatus: 2 }
+          )
+          saveTasks()
+        }
+        if (index !== -1) {
+          taskQueue.splice(index, 1)
+          if (taskQueue.length < maxTask && previous.length) {
+            const { url, path, origin, postTitle } = previous.shift()
+            queueTask({ url, path, origin, postTitle })
+          }
+        }
+      })
+    }
+  })
+  return torrent
+}
+
+// Restore saved tasks after relaunch
+ipcRenderer.on('preload-restore', (e, path) => {
+  console.log('[Preload] Restore', path)
+  try {
+    const p = resolve(path, 'preload-tasks.json')
+    const now = new Date()
+    now.setDate(now.getDate() - 7)
+    const oneWeekAgo = now.valueOf()
+    if (existsSync(p)) {
+      const tasks = JSON.parse(readFileSync(p))
+      for (const task of tasks) {
+        if (!existsSync(task.torrentPath) || !existsSync(task.downloadPath)) {
+          if (existsSync(task.torrentPath)) rmSync(task.torrentPath)
+          if (existsSync(task.downloadPath)) rmSync(task.downloadPath, { recursive: true })
+          continue
+        }
+        if (task.removed) continue
+        const { mtimeMs } = statSync(task.torrentPath)
+        // Remove old caches
+        if (mtimeMs < oneWeekAgo) {
+          rmSync(task.torrentPath)
+          if (existsSync(task.downloadPath)) rmSync(task.downloadPath, { recursive: true })
+          continue
+        }
+        if (task.torrent && task.torrent.downloaded < downloadThreshold) {
+          // This task was not loaded before
+          queueTask({
+            url: task.url,
+            origin: task.origin,
+            path: task.downloadPath,
+            postTitle: task.torrent.postTitle || task.torrent.name
+          })
+          console.log('[Preload] Restart', task.url)
+        } else {
+          console.log('[Preload] Restore', task.url)
+          preloadTasks.set(task.url, task)
+        }
+      }
+      console.log(`[Preload] Restore ${tasks.length} tasks`)
+    }
+    storePath = p
+  } catch (e) {
+    console.log(`Failed to load preloads from ${path}`, e)
+  }
+})
+ipcRenderer.on('preload-task', (e, { url, path, origin, postTitle }) => {
+  if (!preloadTasks.has(url)) {
+    console.log('[Preload] Receive task', { url, path, origin, postTitle })
+    queueTask({ url, path, origin, postTitle })
+  }
+})
+
+export default {
+  /**
+   * @function loadCache
+   * @param { string } url Torrent url to download
+   * @param { string } downloadDirectory Directory to save downloaded pieces
+   * @returns { string|null } Preloaded torrent file path
+   */
+  loadCache (url, downloadDirectory) {
+    if (preloadTasks.has(url)) {
+      // Copy preloaded files to `downloadDirectory` and return the preloaded torrent file
+      const { torrentPath, downloadPath, removed } = preloadTasks.get(url)
+      if (removed) {
+        console.log('Preload task is removed!')
+        return torrentPath
+      }
+      console.log('copy', downloadPath, downloadDirectory)
+      cpSync(downloadPath, downloadDirectory, { recursive: true })
+      // Remove preloaded task as it is added
+      setTimeout(() => {
+        rmSync(downloadPath, { recursive: true })
+        preloadTasks.set(url, { torrentPath, removed: true })
+      }, 5000)
+      return torrentPath
+    }
+    return null
+  },
+  enable () {
+    maxPreload = 40
+    localStorage.setItem('library-max-preload', '40')
+  },
+  disable () {
+    maxPreload = 0
+    localStorage.setItem('library-max-preload', '0')
+    // Remove added tasks
+    removeOldIfNeeded()
+    taskQueue.splice(0)
+    preloadTasks.clear()
+  },
+  // Main module sends data to render process from this map
+  preloadTasks,
+  taskQueue,
+  failures
+}

--- a/dist/electron/UnPackaged/webtorrent.html
+++ b/dist/electron/UnPackaged/webtorrent.html
@@ -28,6 +28,7 @@
     should always in console of the renderer process.
   </div>
   <!-- <script src="wt-extention.js"></script> -->
+  <script src="torrent-file.js"></script>
   <script src="webtorrent.js" type="module"></script>
 </body>
 

--- a/dist/electron/UnPackaged/webtorrent.js
+++ b/dist/electron/UnPackaged/webtorrent.js
@@ -1,1 +1,1347 @@
-const WebTorrent=require("webtorrent"),wtVersion=require("webtorrent/package.json").version,{ipcRenderer:ipcRenderer}=require("electron"),crypto=require("crypto"),fs=require("fs"),path=require("path"),{setSecure:setSecure}=require("webtorrent/lib/peer"),FSChunkStore=require("fs-chunk-store"),is=require("electron-is"),{utimes:utimes}=require("utimes");import{useAlphabizProtocol,useClientEvents}from"./wt-extention.js";import preloader from"./webtorrent-preload.js";import utils from"./webtorrent-utils.js";import natTraversal from"./nat.js";const natPorts=[],isMac=is.macOS(),{setAttributeSync:setAttributeSync,removeAttributeSync:removeAttributeSync,listAttributesSync:listAttributesSync}=isMac?require("fs-xattr"):{setAttributeSync(){},removeAttributeSync(){},listAttributesSync(){}},setUtimes=e=>{if(isMac)if(fs.existsSync(e.path)){const t=Date.now(),r=()=>{setTimeout((()=>{utimes(e.path,{btime:t});const r=listAttributesSync(e.path);r&&r.includes("com.apple.progress.fractionCompleted")&&(console.log(`[Done] Set file progress to 1. ${e.path}`),removeAttributeSync(e.path,"com.apple.progress.fractionCompleted"))}),200)};if(1===e.progress)return r(),console.log(`${e.path} is finished. Skip adding progress.`);e.on("done",r),utimes(e.path,{btime:4437792e5}),setAttributeSync(e.path,"com.apple.progress.fractionCompleted","0.01")}else setTimeout((()=>setUtimes(e)),100)};class TrackerMap extends Map{set(e,t){if("object"!==typeof t)return console.error("Not an object",t);super.set(e,Object.assign({url:e},t,{timestamp:Date.now()}))}}let info=()=>{},verbose=()=>{};Object.defineProperty(global,"log",{set(e){info=e?console.log:()=>{},console.log("Toggle log",e)}}),Object.defineProperty(global,"verb",{set(e){verbose=e?console.log:()=>{},console.log("Toggle verb",e)}});const warn=console.error;let startServerInfoHash;process.env.NODE_ENV;const infoHashes=[],shouldDelete=[],speeder=new Map;let prevTime=Date.now(),deltaTime=1e3;const torrentToJson=e=>utils.torrentToJson(e,deltaTime,speeder),speedLimit=e=>"number"!==typeof e?-1:e>0?parseInt(e):-1,getPublicPath=e=>{if(!e||0===e.length)return"";let t=path.dirname(e[0]);for(let r=1;r<e.length;r++)while(!e[r].includes(t)&&t.length>1)t=path.dirname(t);return t},locked=new Set;window.WEBTORRENT_ANNOUCEMENT=require("create-torrent").announceList.map((e=>e[0]));const VERSION_STR=wtVersion.replace(/\d*./g,(e=>("0"+e%100).slice(-2))).slice(0,4),peerId=Buffer.from(`-WW${VERSION_STR}-${crypto.randomBytes(9).toString("base64")}`);let client=null;const initClient=(e=0)=>{if(e>10)return;if(client&&client.torrents.length)return info("Client is not idle, keep it alive");const t={peerId:peerId,maxConns:20},r=parseInt(localStorage.getItem("dhtPort")),o=parseInt(localStorage.getItem("torrentPort"));isNaN(r)||(t.dhtPort=r),isNaN(o)||(t.torrentPort=o);const n=parseInt(localStorage.getItem("maximumConnectionsNum"));isNaN(n)||(t.maxConns=n);const s=parseInt(localStorage.getItem("downloadSpeed")),i=parseInt(localStorage.getItem("uploadSpeed")),a=Number(localStorage.getItem("payedUserShareRate"));t.blocklist=utils.getLocalIPList()||[];const l=localStorage.getItem("webtorrent-secure")||"auto";["auto","enable","disable"].includes(l)?setSecure(l):(setSecure("auto"),localStorage.setItem("webtorrent-secure","auto")),info("init client",t),client=new WebTorrent(t),client.natTraversal=natTraversal,isNaN(s)||client.throttleDownload(s),isNaN(i)||isNaN(a)||client.throttleUpload(i,a),client.on("error",(t=>{warn(t),r&&o&&(e+=1,info("try use difference port"),localStorage.setItem("dhtPort",r+e),localStorage.setItem("torrentPort",o+e),initClient(e)),ipcRenderer.send("webtorrent-client-error",t.message)})),client.on("warning",(e=>{warn(e),ipcRenderer.send("webtorrent-client-warn",e.message)})),client.on("ready",(()=>{console.log("initted"),ipcRenderer.send("webtorrent-initted")})),client.dht.on("listening",(()=>{const e=client.dht.address();console.log("DHT listening",e),natTraversal.portMapping&&(natTraversal.portMapping(e.port,"udp"),natPorts.push(e.port))})),client.on("listening",(()=>{if(console.log("Client listening",client._connPool),client._connPool&&client._connPool.tcpServer){const e=client._connPool.tcpServer.address();console.log("TCP Server",e),natTraversal.portMapping(e.port,"tcp"),natPorts.push(e.port)}})),window.client=client,useClientEvents(client)};setInterval((()=>{client&&client.torrents.forEach((e=>{e.paused||e.discovery&&e.discovery.tracker&&e.discovery.tracker.update()}))}),1e4);const addTracker=(e,t)=>{const r=t&&t.trim(),o="string"===typeof e?client.get(e):e;o&&o.trackerMap&&(o.trackerMap.has(r)||(console.log("add tracker",e,r,o.trackerMap.get(r),o.trackerMap.size),o.trackerMap.set(r,{status:"connecting"}),utils.addTracker(o,r)))},removeTracker=(e,t)=>{const r="string"===typeof e?client.get(e):e;r&&r.trackerMap&&utils.removeTracker(r,t,(()=>{r.trackerMap.delete(t)}))};global.addTracker=addTracker,global.removeTracker=removeTracker;let sendPreloadTasks="1"===localStorage.getItem("send-preload-tasks");const queueTimeout=(e,t)=>{const r=Date.now(),o=()=>{Date.now()-r>=t?e():requestAnimationFrame(o)};requestAnimationFrame(o)};let shouldSendInfo=!0;const updateTorrent=(e=!1)=>{if(!shouldSendInfo&&!e)return queueTimeout(updateTorrent,1e3),info("skip send");verbose("update torrent");const t=Date.now();deltaTime=(t-prevTime)/1e3,prevTime=t;let r=0,o=0;if(client.torrents.length){const e=client.torrents.filter((e=>!shouldDelete.includes(e.infoHash)&&!(e.isAutoUpload&&!e.ready&&!e.verifyStatus))),t=e.map((e=>{e.done||"number"!==typeof e.usedTime||(e.usedTime+=1e3);const t=torrentToJson(e);if(speeder.has(t.infoHash)&&e.ready){const n=speeder.get(t.infoHash);0===n.downloaded?t.downloadSpeed=0:t.downloadSpeed=Math.floor((e.downloaded-n.downloaded)/deltaTime),0===n.uploaded?t.uploadSpeed=0:t.uploadSpeed=Math.floor((e.uploaded-n.uploaded)/deltaTime),t.downloadSpeed<0&&(t.downloadSpeed=0),t.uploadSpeed<0&&(t.uploadSpeed=0),r+=t.downloadSpeed,o+=t.uploadSpeed,speeder.set(t.infoHash,{downloaded:e.downloaded,uploaded:e.uploaded})}else t.downloadSpeed=0,t.uploadSpeed=0,speeder.set(t.infoHash,{downloaded:0,uploaded:0});return t}));isMac&&t.forEach((e=>{if(e.upload||1===e.progress||e.isSeeding)return;const t=e.files;t.forEach((e=>{if("path"in e&&"progress"in e&&fs.existsSync(e.path)){if(e.progress<.01)return;setAttributeSync(e.path,"com.apple.progress.fractionCompleted",e.progress.toFixed(2))}}))})),info("send torrents",t),ipcRenderer.send("webtorrent-torrents",t)}else client.ready&&ipcRenderer.send("webtorrent-torrents",[]);if(ipcRenderer.send("webtorrent-client-info",{downloadSpeed:r<0?0:r,uploadSpeed:o<0?0:o,progress:client.progress,taskNum:client.torrents.length}),client.torrents.length>50&&(client.maxConns=Math.min(client.maxConns,10)),!e){if(sendPreloadTasks){const e=[];for(const[t,r]of preloader.preloadTasks.entries()){const{torrentPath:o,downloadPath:n,torrent:s}=r;s&&e.push({abUrl:t,torrentPath:o,downloadPath:n,torrent:s,postTitle:s.postTitle||""})}for(const t of preloader.taskQueue)e.find((e=>e.abUrl===t.url))||e.push({abUrl:t.origin,torrentPath:null,downloadPath:null,torrent:null,postTitle:t.postTitle});for(const t of preloader.failures)e.find((e=>e.abUrl===t.url))||e.push({abUrl:t.origin,torrentPath:null,downloadPath:null,torrent:null,postTitle:t.postTitle,failed:!0});ipcRenderer.send("webtorrent-preload",e)}else ipcRenderer.send("webtorrent-preload",[]);client.torrents.length>100?(client.maxConns=Math.min(client.maxConns,5),queueTimeout(updateTorrent,2e3)):queueTimeout(updateTorrent,1e3)}};queueTimeout(updateTorrent,1e3);let queueUpdate=null;const forceUpdateTorrent=()=>{queueUpdate&&(clearTimeout(queueUpdate),queueUpdate=setTimeout((()=>{queueUpdate=null,updateTorrent(!0)}),100))},onDone=e=>{if(setTimeout((()=>{isMac&&e.files&&e.files.length&&e.files.forEach((e=>{const t=listAttributesSync(e.path);t&&t.includes("com.apple.progress.fractionCompleted")&&(console.log(`[Done] Set file progress to 1. ${e.path}`),removeAttributeSync(e.path,"com.apple.progress.fractionCompleted","1"))}))}),1e3),e.upload)return console.log("skip upload");e.isSeeding=!0;const t=torrentToJson(e);e.completedTime||(e.completedTime=Date.now()),ipcRenderer.send("webtorrent-done",t),ipcRenderer.send("webtorrent-finish-all-payments",t)},onReady=e=>{e.files.forEach((e=>{e.name.match(/^_____padding_file_(.*)____$/)&&info("deselect",e.name),isMac&&e.path&&setUtimes(e)}));const t=torrentToJson(e);info("ready",t),ipcRenderer.send("webtorrent-ready",t),startServerInfoHash===t.infoHash&&(startServer(t.infoHash,t),startServerInfoHash=""),0===client.torrents.filter((e=>!e.ready)).length&&info("All torrents are ready")},onMetadata=(e,t)=>{ipcRenderer.send("webtorrent-metadata",e.infoHash),ipcRenderer.send("webtorrent-data",torrentToJson(e))},onWire=(e,t,r)=>{if(e.use(r),"webrtc"===e.type){const r=()=>{if(e.remoteAddress)return;const o=t._peers[e.peerId];if(!o)return setTimeout(r,1e3);const n=o.conn?._pc?.currentRemoteDescription?.sdp?.match(/c=IN\sIP\d\s(.*)/)?.[1];if(!n)return setTimeout(r,1e3);e.remoteAddress=n};r()}},onInfoHash=(e,t,r,o)=>{info("infoHash",e);while(shouldDelete.includes(e))shouldDelete.splice(shouldDelete.indexOf(e),1);infoHashes.includes(e)&&client.get(e)!==t?(info("Destroy tr"),ipcRenderer.send("webtorrent-existed",e),t.destroy()):ipcRenderer.send("webtorrent-infohash",e,{...r,isSeeding:o}),infoHashes.push(e),forceUpdateTorrent()},addListeners=(e,t={},r=!1)=>{t||(t={}),e.pending=!1,e.removeAllListeners(),e.setMaxListeners(0),info(`Add listeners to torrent ${e.infoHash||e.token||e.origin}`),e.on("done",(()=>onDone(e))),e.on("ready",(()=>onReady(e))),e.on("metadata",(()=>onMetadata(e,t))),e.on("infoHash",(o=>{onInfoHash(o,e,t,r)})),e.on("warning",(()=>{})),e.on("error",(r=>{console.log("Torrent error",r,t),ipcRenderer.send("webtorrent-error",torrentToJson(e),r.message)}));const o=useAlphabizProtocol(client,e);e.on("wire",(t=>onWire(t,e,o))),e.on("discovery",(()=>{if(e.discovery){if(info("start discovery"),e.trackerMap=new TrackerMap,e.discovery._announce.forEach((t=>{if(verbose("Discovered",t),e.trackerMap.set(t,{status:"connecting"}),!t.startsWith("ws")){if(t.match(/(\d{1,3}\.){3}\d{1,3}/))return;e.trackerMap.set(t+"@6",{status:"connecting"})}})),e.discovery.tracker.on("warning",((t,r,o)=>{if(verbose("tracker warning",r,t.message,o),!r)return console.warn("No emitted url",t);6===o&&(r+="@6"),e.trackerMap.set(r,{status:"error",message:utils.parseTrackerWarning(t.message)})})),e.discovery.tracker.on("update",((t,r,o)=>{if(verbose("tracker update",r,t),!r)return console.warn("No emitted url",t);6===o&&(r+="@6"),e.trackerMap.set(r,{status:"updated",info:t})})),t.customTrackers)for(const r of t.customTrackers)addTracker(e,r)}else info("no discovery")}))},addTorrent=(e,t,r)=>{if(verbose("Add torrent",e,t),t.isSeeding&&1===t.progress)return seedTorrent(e,t.file,t);if(t.infoHash){const e=t.infoHash.match(/btih:([^&]*)/),r=e&&e[1]||t.infoHash;if(r&&client.get(r))return info("exist",client.get(r)),ipcRenderer.send("webtorrent-existed",r)}if(t.origin){if(locked.has(t.origin))return info("origin lock",t.origin),locked.delete(t.origin);locked.add(t.origin)}if(t.token!==t.origin){if(locked.has(t.token))return info("token lock",t.token),info(locked),locked.delete(t.token);locked.add(t.token)}const o=()=>{const o=t.torrentPath&&fs.existsSync(t.torrentPath)?t.torrentPath:fs.existsSync(t.token||t.origin)?t.token||t.origin:t.infoHash;info(o);const n=client.add(o,{path:t.path||t.downloadDirectory,store:FSChunkStore,storeOpts:{postTitle:t.postTitle||""},storeCacheSlots:1,strategy:"sequential",maxWebConns:client.maxConns,announce:[...t.trackers||[],...WEBTORRENT_ANNOUCEMENT]});n.token=e,n.origin=t.infoHash||t.token||t.origin,n.createdTime=t.createdTime||Date.now(),n.usedTime=t.usedTime||0,t.fromPost&&(n.fromPost=t.fromPost),t.postTitle&&(n.postTitle=t.postTitle),t.name&&(n.name=t.name),t.subtitleList&&t.subtitleList.length&&(n.subtitleList=t.subtitleList),verbose("Torrent conf",n),addListeners(n,t),verbose("Listener added"),n.once("infoHash",(()=>{locked.delete(t.origin),locked.delete(n.infoHash),locked.delete(t.token),r&&r(n)})),t.verifiedPieces&&n.once("metadata",(()=>{if(n.length<2e8)return;let e=0,r=.2;n.length>5e9&&(r=.1),n.length>2e10&&(r=.05),n.length>5e10&&(r=.01),n.length>1e11&&(r=.005),t.verifiedPieces.forEach((t=>{if(Array.isArray(t)){const[r,o]=t;for(let t=r+1;t<o-1;t++)n._markVerified(t),e++}else isNaN(t)||(n._markVerified(t),e++)})),info("mark verified",t.verifiedPieces,e)}))};if(client.get(t.infoHash))client.remove(t.infoHash,o);else if(client.torrents.some((t=>t.token===e))){const t=client.torrents.find((t=>t.token===e));if(!t)return o();if(t.infoHash)return r&&r(t);t.once("infoHash",(()=>r&&r(t)))}else o()},stopTorrent=e=>{if(locked.has(e))return;locked.add(e),server&&serverInfoHash===e&&(server.destroy(),server=null,serverInfoHash="");const t=client.get(e);if(t&&(t.isSeeding||t.done)&&(t.completed=!0),t)ipcRenderer.send("webtorrent-finish-all-payments",torrentToJson(t)),t.destroy((()=>{locked.delete(e),ipcRenderer.send("webtorrent-stop",e,t.completed)}));else if(locked.delete(e),e){const t=client.torrents.find((t=>t.token===e));t&&t.destroy((()=>{locked.delete(e),ipcRenderer.send("webtorrent-stop",e,t.completed)}))}else ipcRenderer.send("webtorrent-notfound",e);infoHashes.includes(e)&&infoHashes.splice(infoHashes.indexOf(e),1),forceUpdateTorrent()},deleteTorrent=(e,t,r)=>{if(locked.has(e))return;locked.add(e),shouldDelete.push(e),server&&serverInfoHash===e&&(server.destroy(),server=null,serverInfoHash="");const o=client.get(e)||client.torrents.find((t=>t.token===e));if(info("delete",e,o,t),o){o.emit("deleted"),info("emit",o.emit);const n=o.files.length?o.files.map((e=>e.path)):o.file||[],s=getPublicPath(n);o.destroy({destroyStore:t},(()=>{"function"===typeof r&&r(),t?ipcRenderer.send("webtorrent-delete",o.infoHash||e,s,n):ipcRenderer.send("webtorrent-delete",o.infoHash||e),locked.delete(e);try{client.remove(o.infoHash)}catch(i){}}))}else locked.delete(e),ipcRenderer.send("webtorrent-notfound",e);while(infoHashes.includes(e))infoHashes.splice(infoHashes.indexOf(e),1);forceUpdateTorrent()},seedTorrent=(e,t,r,o=!1,n=null)=>{if(r.infoHash&&client.get(r.infoHash))return info("skip existed",r.infoHash);const s=r.infoHash||r.token||r.origin||(Array.isArray(t)?t[0]:t);if(s){if(locked.has(s))return;locked.add(s)}let i=null;const a=[...r.trackers||[],...WEBTORRENT_ANNOUCEMENT],l={...r,store:FSChunkStore,storeOpts:{postTitle:r.postTitle||""},storeCacheSlots:1,strategy:"sequential",maxWebConns:client.maxConns,announce:a};if(r.infoHash&&!r.upload&&r.files.length)info("[seed] add torrent with token"),info(r),i=client.add(r.infoHash||r.token||r.origin,Object.assign(l,{path:r.path||r.downloadDirectory,skipVerify:1===r.progress}));else if(r.isSeeding&&r.torrentPath&&fs.existsSync(r.torrentPath))info("[seed] add torrent with torrentPath"),i=client.add(r.torrentPath,Object.assign(l,{path:r.path||r.downloadDirectory,skipVerify:!0}));else if(r.isSeeding&&r.magnetURI&&!r.isUploadByFiles)info("[seed] add torrent with magnetURI"),i=client.add(r.magnetURI,Object.assign(l,{path:r.path||r.downloadDirectory,skipVerify:!0})),i.upload=!0,i.isSeeding=!0;else{info("[seed] Seed torrent with files",!!r.infoHash,r);const e=client.torrents.filter((e=>1===e.progress)),o=e.reduce(((e,t)=>{const r=t.files.map((e=>e.path));return e.push(...r),e}),[]);t.some((e=>o.includes(e)))&&ipcRenderer.send("webtorrent-seed-error","task_exists"),i=client.seed(t,Object.assign(l,{skipVerify:!!r.infoHash,onProgress(e,t){i.verifyStatus={current:e,total:t}}})),i.isUploadByFiles=!0}return info("seedTorrent",r,i,t),r.name&&(i.name=r.name),i.isAutoUpload=o,i.token=e,i.isSeeding=!0,i.upload=!0,i.paused=!1,i.file=t,i.createdTime=r.createdTime||Date.now(),addListeners(i,r,!0),i.once("infoHash",(()=>{locked.delete(s),n&&n()})),i.once("metadata",(()=>{ipcRenderer.send("webtorrent-seed",torrentToJson(i))})),i.once("deleted",(()=>{l.onProgress&&(l.onProgress._destroyed=!0)})),i},getTorrent=()=>{const e=client.torrents.map((e=>torrentToJson(e)));return info(e),ipcRenderer.send("webtorrent-list",e)},setThrottleGroup=({infoHash:e,peerId:t,subId:r,level:o})=>{const n=client.get(e);if(!n)return info("not found",e),ipcRenderer.send("webtorrent-set-throttle",{code:-1,message:"Torrent Not Found"}),null;let s=null,i=null;for(const l of n.wires)if(r?l.remoteSub===r:l.peerId===t){s=l;try{l._setThrottleGroup(o)}catch(a){i={code:-1,message:a.message}}break}return s?i?ipcRenderer.send("webtorrent-set-throttle",i):ipcRenderer.send("webtorrent-set-throttle",{code:0,message:"success"}):ipcRenderer.send("webtorrent-set-throttle",{code:-1,message:"Peer Not Found"}),s},saveTorrentFile=(e,t)=>{const r="webtorrent-save-torrent",o=client.get(e);if(!o)return;if(!o.torrentFile||!o.name)return ipcRenderer.send(r,{code:-1,message:"Torrent Not Ready"});const n=path.resolve(t,`${o.name}.torrent`);if(fs.existsSync(n))return ipcRenderer.send(r,{code:0,message:"success",infoHash:e,torrentPath:n});fs.existsSync(t)||fs.mkdirSync(t,{recursive:!0}),fs.writeFileSync(n,o.torrentFile),ipcRenderer.send(r,{code:0,message:"success",infoHash:e,torrentPath:n})};let server=null,serverInfoHash="";const startTorrentServer=e=>{if(info("Start server",e),startServerInfoHash="",server){if(serverInfoHash===e.infoHash)return ipcRenderer.send("webtorrent-server-ready",e.infoHash,{token:e.token,port:server.address().port});server.destroy(),server=null,serverInfoHash=""}info("Create server",e),server=e.createServer(),server.listen(0,(()=>{const t=server.address().port,r={token:e.token,port:t};ipcRenderer.send("webtorrent-server-ready",e.infoHash,r);const o=()=>{const t=e.files.map((t=>{const r=[];for(let o=t._startPiece;o<t._endPiece;o++)r.push(null===e.pieces[o]?1:0);return{name:t.name,path:t.path,progress:r}}));ipcRenderer.send("webtorrent-server-progress",e.infoHash,t)};setTimeout(o,1e3);const n=setInterval(o,5e3);server.once("close",(()=>clearInterval(n)))}))},startServer=(e,t)=>{info("start server",e,t),startServerInfoHash=e;const r=client.get(e);if(!r)return addTorrent(t.token||t.infoHash,t,(()=>startServer(e,t)));r.ready?(info("tr ready. start server"),startTorrentServer(r,t)):r.once("ready",(()=>startTorrentServer(r,t)))},stopServer=()=>{server&&(server.destroy(),server=null,serverInfoHash="",info("Destroy server"))};(function(){ipcRenderer.once("redirect-log",((e,t)=>{console.log("Write webtorrent logs to",t),utils.useRedirectLogs(t)})),ipcRenderer.on("add-torrent",((e,t,r)=>{if(r.magnetURI&&!r.torrentPath){const e=preloader.loadCache(r.magnetURI,r.path);e?(console.log("[Preload] Load cached task",e),r.torrentPath=e):console.log("Cannot find preloaded task for",r)}return addTorrent(t,r)})),ipcRenderer.on("stop-torrent",((e,t)=>(console.log("got stop",t),stopTorrent(t)))),ipcRenderer.on("stop-all-uploading",((e,t)=>{t.forEach((e=>{const t=client.torrents.find((t=>!(!t.infoHash||t.infoHash!==e.infoHash)||!(!t.token||t.token!==e.token)));t&&t.destroy()}))})),ipcRenderer.on("delete-all",((e,t,r,o)=>{shouldSendInfo=!1,info("Delete all",t,r,o);const n=client.torrents.filter((e=>{if("all"===t)return!0;const r=e.upload||1===e.progress||e.isSeeding;return"upload"===t?!(!o&&e.isAutoUpload)&&r:!r}));if(!n.length)return void(shouldSendInfo=!0);let s=0;n.forEach((t=>{s++,info(t.infoHash),shouldDelete.push(t.infoHash),t.removeAllListeners();try{deleteTorrent(t.infoHash,r,(()=>{shouldDelete.includes(t.infoHash)&&shouldDelete.splice(shouldDelete.indexOf(t.infoHash),1),s--,0===s&&(shouldSendInfo=!0)}))}catch(e){}})),setTimeout((()=>{shouldSendInfo=!0}),2e3)})),ipcRenderer.on("seed-torrent",((e,t)=>{let{file:r,token:o,...n}=t;return r||(r=t.files.map((e=>e.path))),console.log(t),r.length?(o||(o=Math.random().toString().substr(2)),seedTorrent(o,r,n)):ipcRenderer.send("seed-error")})),ipcRenderer.on("seed-torrents",((e,t)=>{info(`Seed ${t.length} torrents`),t.forEach((e=>{let{file:t,token:r,...o}=e;t||(t=e.files.map((e=>e.path))),r||(r=Math.random().toString().substring(2)),seedTorrent(r,t,{...e})}))})),ipcRenderer.on("autoupload-files",(async(e,t)=>{info("autoupload files",t),Promise.all(t.map((e=>{if(info("Auto upload",e),!client.torrents.some((t=>t.files.some((t=>t.path===e))||t.file&&t.file.some&&t.file.some((t=>t===e))||t.file===e)))return new Promise((t=>{seedTorrent("autoupload-"+path.basename(e),[e],{path:path.dirname(e)},!0,t)}));info(`${e} is already uploaded, skipped`)}))).then((()=>{info("autoupload complete"),ipcRenderer.send("autoupload-complete")})).catch((e=>{ipcRenderer.send("autoupload-complete",e.message||e)}));const r=[];client.torrents.forEach((e=>{e.isAutoUpload&&e.ready&&(e.files.some((e=>t.includes(e.path)))?info(`${e.infoHash} is kept alive`):(info(`${e.infoHash} has been deleted. Destroy`,e.files.map((e=>e.path))),r.push(e)))})),r.forEach((e=>{e.destroy((()=>{ipcRenderer.send("webtorrent-delete",e.infoHash)}))}))})),ipcRenderer.on("start-server",((e,{infoHash:t,conf:r})=>(info("start server",t,r),startServer(t,r)))),ipcRenderer.on("stop-server",(()=>stopServer())),ipcRenderer.on("delete-torrent",((e,t,r)=>deleteTorrent(t,r))),ipcRenderer.on("pend-torrent",((e,t)=>{const r=client.get(t.infoHash);infoHashes.includes(t.infoHash)&&infoHashes.splice(infoHashes.indexOf(t.infoHash),1),info("Pend",t.infoHash,r),r&&(r.removeAllListeners(),r.destroy(),r.pending=!0,ipcRenderer.send("webtorrent-pending",torrentToJson(r)))})),ipcRenderer.on("set-throttle-group",((e,{infoHash:t,peerId:r,subId:o,level:n})=>{info(t,r,o,n),setThrottleGroup({infoHash:t,peerId:r,subId:o,level:n})})),ipcRenderer.on("save-torrent-file",((e,t,r)=>saveTorrentFile(t,r))),ipcRenderer.on("update-settings",((e,{uploadSpeed:t,downloadSpeed:r,maximumConnectionsNum:o,DHTlistenPort:n,BTlistenPort:s,payedUserShareRate:i,secureOption:a,libraryPreload:l,showPreload:d})=>{const c=parseInt(n),p=parseInt(s);if(info("Set client",{uploadSpeed:t,downloadSpeed:r,maximumConnectionsNum:o,dhtPort:c,torrentPort:p,payedUserShareRate:i,secureOption:a,libraryPreload:l,showPreload:d}),i){const e=Number(i)||.7;localStorage.setItem("payedUserShareRate",e.toString())}if(t){const e=speedLimit(t);localStorage.setItem("uploadSpeed",e.toString())}const f=Number(localStorage.getItem("payedUserShareRate"))||.7,u=parseInt(localStorage.getItem("uploadSpeed"));if(isNaN(f)||isNaN(u)||(-1===u?client.throttleUpload(-1):client.throttleUpload(u,f)),r){const e=speedLimit(r);client.throttleDownload(e),localStorage.setItem("downloadSpeed",e.toString())}o&&(client.maxConns=o,localStorage.setItem("maximumConnectionsNum",o.toString()));let h=!1;c&&c!==parseInt(localStorage.getItem("dhtPort"))&&(h=!0,localStorage.setItem("dhtPort",c.toString())),p&&p!==parseInt(localStorage.getItem("torrentPort"))&&(h=!0,localStorage.setItem("torrentPort",p.toString())),"string"===typeof a&&(localStorage.setItem("webtorrent-secure",a),setSecure(a),info("set secure",a)),h&&location.reload(),!0===l?preloader.enable():!1===l&&preloader.disable(),!0===d?(sendPreloadTasks=!0,localStorage.setItem("send-preload-tasks","1")):!1===d&&(sendPreloadTasks=!1,localStorage.setItem("send-preload-tasks","0"))})),ipcRenderer.on("reset-torrent",(()=>{info("reset"),shouldSendInfo=!1,Promise.all(client.torrents.map((e=>new Promise((t=>{e.removeAllListeners(),e.destroy({destroyStore:!0},t)}))))).then((()=>ipcRenderer.send("webtorrent-reset"))).catch((()=>ipcRenderer.send("webtorrent-reset-error"))).finally((()=>{info("resetted"),client.torrents.length=0,shouldSendInfo=!0}))})),ipcRenderer.on("add-tracker",((e,{infoHash:t,url:r})=>{info("add-tracker",t,r),addTracker(t,r)})),ipcRenderer.on("remove-tracker",((e,{infoHash:t,url:r})=>{info("remove-tracker",t,r),removeTracker(t,r)})),ipcRenderer.on("force-exit",(()=>process.exit(0))),setInterval((()=>{process.memoryUsage().rss/1e9>3.5&&(info("exit for memory reason"),process.exit(0))}),6e4),initClient(0),window.addEventListener("error",(e=>(info(e.message||e),!0))),ipcRenderer.on("before-quit",(()=>{natPorts.forEach((e=>{natTraversal.portUnMapping(e)}))})),"undefined"!==typeof window&&window.addEventListener("beforeunload",(()=>{natPorts.forEach((e=>{natTraversal.portUnMapping(e)}))}))})();
+const WebTorrent = require('webtorrent')
+const wtVersion = require('webtorrent/package.json').version
+const { ipcRenderer } = require('electron')
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const { saveTorrentByName } = globalThis.alphabizTorrentFile || {}
+if (typeof saveTorrentByName !== 'function') {
+  throw new Error('Torrent file security boundary is not loaded')
+}
+const { setSecure } = require('webtorrent/lib/peer')
+// const diskusage = require('diskusage')
+const FSChunkStore = require('fs-chunk-store')
+const is = require('electron-is')
+const { utimes } = require('utimes')
+
+import { useAlphabizProtocol, useClientEvents } from './wt-extention.js'
+import preloader from './webtorrent-preload.js'
+import utils from './webtorrent-utils.js'
+import natTraversal from './nat.js'
+const natPorts = []
+
+const isMac = is.macOS()
+const { setAttributeSync, removeAttributeSync, listAttributesSync } = isMac ? require('fs-xattr') : {
+  setAttributeSync () {},
+  removeAttributeSync () {},
+  listAttributesSync () {}
+}
+
+const setUtimes = (file) => {
+  if (!isMac) return
+  if (fs.existsSync(file.path)) {
+    const createdTime = Date.now()
+    const onDone = () => {
+      setTimeout(() => {
+        utimes(file.path, {
+          btime: createdTime
+        })
+        const attrs = listAttributesSync(file.path)
+        if (attrs && attrs.includes('com.apple.progress.fractionCompleted')) {
+          console.log(`[Done] Set file progress to 1. ${file.path}`)
+          // Reset created time
+          removeAttributeSync(file.path, 'com.apple.progress.fractionCompleted')
+        }
+      }, 200)
+    }
+    if (file.progress === 1) {
+      onDone()
+      return console.log(`${file.path} is finished. Skip adding progress.`)
+    }
+    file.on('done', onDone)
+    /**
+     * DO NOT TOUCH!
+     * The number is a magic code used by macOS. If the create time of file
+     * is not set to this value, the download progress pie will not shown
+     * in finder. This is the timestamp of `1984-01-24 08:00:00 +0000`.
+     */
+    utimes(file.path, {
+      btime: 443779200000
+    })
+    setAttributeSync(file.path, 'com.apple.progress.fractionCompleted', '0.01')
+  } else {
+    setTimeout(() => setUtimes(file), 100)
+  }
+}
+
+/**
+ * @typedef { import('../src/types').TrackerStatus } TrackerStatus
+ */
+/**
+ * @class TrackerMap
+ * @extends { Map<string, TrackerStatus> }
+ */
+class TrackerMap extends Map {
+  /**
+   * @method set
+   * @param { string } key
+   * @param { TrackerStatus } value
+   */
+  set (key, value) {
+    if (typeof value !== 'object') return console.error('Not an object', value)
+    super.set(key, Object.assign(
+      { url: key },
+      value,
+      { timestamp: Date.now() }
+    ))
+  }
+}
+
+let info = () => {} // console.log
+let verbose = () => {} // console.log
+// Use this to keep logger with correct caller line
+Object.defineProperty(global, 'log', {
+  set (v) {
+    if (v) info = console.log
+    else info = () => {}
+    console.log('Toggle log', v)
+  }
+})
+Object.defineProperty(global, 'verb', {
+  set (v) {
+    if (v) verbose = console.log
+    else verbose = () => {}
+    console.log('Toggle verb', v)
+  }
+})
+const warn = console.error
+if (process.env.NODE_ENV === 'development') {
+  // global.log = true
+  // global.verb = true
+}
+let startServerInfoHash
+const infoHashes = []
+const shouldDelete = []
+/**
+ * @typedef { import('../src/types').TorrentInfo } TorrentInfo
+ * @typedef { import('webtorrent/lib/torrent') } RawTorrent
+ * @typedef { RawTorrent & TorrentInfo } Torrent
+ */
+// The lib `speedometer` webtorrent dependents performed bad.
+// Use customized speeder instead.
+const speeder = new Map()
+let prevTime = Date.now()
+let deltaTime = 1000
+/**
+ * @method torrentToJson
+ * @param { Torrent } tr
+ * @param { boolean } isUpload
+ * @returns { Partial<Torrent> }
+ */
+const torrentToJson = (tr) => {
+  return utils.torrentToJson(tr, deltaTime, speeder)
+}
+/** @param { number } speed */
+const speedLimit = speed => {
+  if (typeof speed !== 'number') return -1
+  return speed > 0 ? parseInt(speed) : -1
+}
+/** @param { string[] } paths */
+const getPublicPath = (paths) => {
+  if (!paths || paths.length === 0) return ''
+  let dir = path.dirname(paths[0])
+  for (let i = 1; i < paths.length; i++) {
+    while (!paths[i].includes(dir) && dir.length > 1) {
+      dir = path.dirname(dir)
+    }
+  }
+  return dir
+}
+
+const locked = new Set()
+
+/**
+ * @typedef { import('src/types').TorrentInfo } TorrentInfo
+ * @typedef { import('webtorrent/lib/torrent') } RawTorrent
+ * @typedef { RawTorrent & TorrentInfo } Torrent
+ */
+
+window.WEBTORRENT_ANNOUCEMENT = require('create-torrent').announceList
+  .map(arr => arr[0])
+
+const VERSION_STR = wtVersion
+  .replace(/\d*./g, v => `0${v % 100}`.slice(-2))
+  .slice(0, 4)
+const peerId = Buffer.from(`-WW${VERSION_STR}-${crypto.randomBytes(9).toString('base64')}`)
+
+/** @type { WebTorrent.Instance } */
+let client = null
+const initClient = (retries = 0) => {
+  if (retries > 10) return
+  if (client) {
+    if (client.torrents.length) return info('Client is not idle, keep it alive')
+  }
+
+  const conf = {
+    peerId,
+    maxConns: 20
+  }
+  const dhtPort = parseInt(localStorage.getItem('dhtPort'))
+  const torrentPort = parseInt(localStorage.getItem('torrentPort'))
+  if (!isNaN(dhtPort)) conf.dhtPort = dhtPort
+  if (!isNaN(torrentPort)) conf.torrentPort = torrentPort
+  const maxConns = parseInt(localStorage.getItem('maximumConnectionsNum'))
+  if (!isNaN(maxConns)) conf.maxConns = maxConns
+  const downloadSpeed = parseInt(localStorage.getItem('downloadSpeed'))
+  const uploadSpeed = parseInt(localStorage.getItem('uploadSpeed'))
+  const payedUserShareRate = Number(localStorage.getItem('payedUserShareRate'))
+  // block local IP
+  conf.blocklist = utils.getLocalIPList() || []
+
+  // Secure setting
+  // conf.secure = true
+  const secureOption = localStorage.getItem('webtorrent-secure') || 'auto'
+  if (['auto', 'enable', 'disable'].includes(secureOption)) {
+    setSecure(secureOption)
+  } else {
+    setSecure('auto')
+    localStorage.setItem('webtorrent-secure', 'auto')
+  }
+
+  info('init client', conf)
+  client = new WebTorrent(conf)
+  client.natTraversal = natTraversal
+  if (!isNaN(downloadSpeed)) client.throttleDownload(downloadSpeed)
+  if (!isNaN(uploadSpeed) && !isNaN(payedUserShareRate)) client.throttleUpload(uploadSpeed, payedUserShareRate)
+  client.on('error', e => {
+    warn(e)
+    if (dhtPort && torrentPort) {
+      retries += 1
+      info('try use difference port')
+      localStorage.setItem('dhtPort', dhtPort + retries)
+      localStorage.setItem('torrentPort', torrentPort + retries)
+      initClient(retries)
+    }
+    ipcRenderer.send('webtorrent-client-error', e.message)
+  })
+  client.on('warning', e => {
+    warn(e)
+    ipcRenderer.send('webtorrent-client-warn', e.message)
+  })
+  client.on('ready', () => {
+    console.log('initted')
+    ipcRenderer.send('webtorrent-initted')
+  })
+  client.dht.on('listening', () => {
+    const address = client.dht.address()
+    console.log('DHT listening', address)
+    if (natTraversal.portMapping) {
+      natTraversal.portMapping(address.port, 'udp')
+      natPorts.push(address.port)
+    }
+  })
+  client.on('listening', () => {
+    console.log('Client listening', client._connPool)
+    if (client._connPool && client._connPool.tcpServer) {
+      const address = client._connPool.tcpServer.address()
+      console.log('TCP Server', address)
+      natTraversal.portMapping(address.port, 'tcp')
+      natPorts.push(address.port)
+    }
+  })
+  window.client = client
+  useClientEvents(client)
+}
+setInterval(() => {
+  if (!client) return
+  client.torrents.forEach(torrent => {
+    if (torrent.paused) return
+    if (!torrent.discovery || !torrent.discovery.tracker) return
+    torrent.discovery.tracker.update()
+  })
+}, 10_000)
+
+/**
+ * @param { string | Torrent } infoHash
+ * @param { string } url
+ */
+const addTracker = (infoHash, _url) => {
+  const url = _url && _url.trim()
+  /** @type { Torrent } */
+  const tr = typeof infoHash === 'string' ? client.get(infoHash) : infoHash
+  if (!tr || !tr.trackerMap) return
+  if (tr.trackerMap.has(url)) return
+  console.log('add tracker', infoHash, url, tr.trackerMap.get(url), tr.trackerMap.size)
+  tr.trackerMap.set(url, { status: 'connecting' })
+  utils.addTracker(tr, url)
+}
+/**
+ * @param { string | Torrent } infoHash
+ * @param { string } url
+ */
+const removeTracker = (infoHash, url) => {
+  /** @type { Torrent } */
+  const tr = typeof infoHash === 'string' ? client.get(infoHash) : infoHash
+  if (!tr || !tr.trackerMap) return
+  utils.removeTracker(tr, url, () => {
+    tr.trackerMap.delete(url)
+  })
+}
+global.addTracker = addTracker
+global.removeTracker = removeTracker
+
+let sendPreloadTasks = localStorage.getItem('send-preload-tasks') === '1' ? true : false
+/**
+ * `setTimeout` cannot be triggered if client is busy.
+ * Here we use rAF to ensure out callback runs as fast as posible
+ */
+const queueTimeout = (cb, timeout) => {
+  const start = Date.now()
+  const run = () => {
+    if (Date.now() - start >= timeout) cb()
+    else requestAnimationFrame(run)
+  }
+  requestAnimationFrame(run)
+}
+let shouldSendInfo = true
+const updateTorrent = (once = false) => {
+  // console.time('torrent status')
+  if (!shouldSendInfo && !once) {
+    queueTimeout(updateTorrent, 1000)
+    return info('skip send')
+  } else {
+    verbose('update torrent')
+  }
+  const curTime = Date.now()
+  deltaTime = (curTime - prevTime) / 1000
+  prevTime = curTime
+  let totalDownloadSpeed = 0
+  let totalUploadSpeed = 0
+  if (client.torrents.length) {
+    const allTorrents = client.torrents.filter(i => {
+      if (shouldDelete.includes(i.infoHash)) return false
+      if (i.isAutoUpload && !i.ready && !i.verifyStatus) return false
+      return true
+    })
+    const torrents = allTorrents.map(tr => {
+      if (!tr.done && typeof tr.usedTime === 'number') tr.usedTime += 1000
+      const t = torrentToJson(tr)
+      if (!speeder.has(t.infoHash) || !tr.ready) {
+        t.downloadSpeed = 0
+        t.uploadSpeed = 0
+        speeder.set(t.infoHash, {
+          downloaded: 0,
+          uploaded: 0
+        })
+      } else {
+        const prev = speeder.get(t.infoHash)
+        if (prev.downloaded === 0) t.downloadSpeed = 0
+        else t.downloadSpeed = Math.floor((tr.downloaded - prev.downloaded) / deltaTime)
+        if (prev.uploaded === 0) t.uploadSpeed = 0
+        else t.uploadSpeed = Math.floor((tr.uploaded - prev.uploaded) / deltaTime)
+        // if (!t.upload) info(prev.downloaded, tr.downloaded, t.downloadSpeed, deltaTime)
+        if (t.downloadSpeed < 0) t.downloadSpeed = 0
+        if (t.uploadSpeed < 0) t.uploadSpeed = 0
+        totalDownloadSpeed += t.downloadSpeed
+        totalUploadSpeed += t.uploadSpeed
+        speeder.set(t.infoHash, {
+          downloaded: tr.downloaded,
+          uploaded: tr.uploaded
+        })
+      }
+      return t
+    })
+    if (isMac) {
+      // TODO: update download progress for finder
+      torrents.forEach(tr => {
+        if (tr.upload || tr.progress === 1 || tr.isSeeding) return
+        // console.log('update progress for', tr)
+        const files = tr.files
+        files.forEach(f => {
+          if (('path' in f) && ('progress' in f) && fs.existsSync(f.path)) {
+            // The min value is '0.01'
+            if (f.progress < 0.01) return
+            // Set file progress
+            // console.log(`[Progress] Set file progress to ${f.progress}. ${f.path}`)
+            setAttributeSync(f.path, 'com.apple.progress.fractionCompleted', f.progress.toFixed(2))
+          }
+        })
+      })
+    }
+    info('send torrents', torrents)
+    // window._torrents = torrents
+    // torrents.forEach(tr => ipcRenderer.send('webtorrent-data', tr))
+    ipcRenderer.send('webtorrent-torrents', torrents)
+  } else if (client.ready) {
+    ipcRenderer.send('webtorrent-torrents', [])
+  }
+  ipcRenderer.send('webtorrent-client-info', {
+    downloadSpeed: totalDownloadSpeed < 0 ? 0 : totalDownloadSpeed,
+    uploadSpeed: totalUploadSpeed < 0 ? 0 : totalUploadSpeed,
+    progress: client.progress,
+    taskNum: client.torrents.length
+  })
+  // console.timeEnd('torrent status')
+  // if there are too many torrents in the client
+  // send info every seconds may cause performance issue
+  if (client.torrents.length > 50) {
+    client.maxConns = Math.min(client.maxConns, 10)
+  }
+  if (once) return
+  if (sendPreloadTasks) {
+    const preloadTasks = []
+    for (const [abUrl, values] of preloader.preloadTasks.entries()) {
+      const { torrentPath, downloadPath, torrent } = values
+      if (!torrent) continue
+      preloadTasks.push({ abUrl, torrentPath, downloadPath, torrent, postTitle: torrent.postTitle || '' })
+    }
+    for (const task of preloader.taskQueue) {
+      if (preloadTasks.find(t => t.abUrl === task.url)) continue
+      preloadTasks.push({
+        abUrl: task.origin,
+        torrentPath: null,
+        downloadPath: null,
+        torrent: null,
+        postTitle: task.postTitle
+      })
+    }
+    for (const task of preloader.failures) {
+      if (preloadTasks.find(t => t.abUrl === task.url)) continue
+      preloadTasks.push({
+        abUrl: task.origin,
+        torrentPath: null,
+        downloadPath: null,
+        torrent: null,
+        postTitle: task.postTitle,
+        failed: true
+      })
+    }
+    // console.log('send preload tasks', preloadTasks)
+    ipcRenderer.send('webtorrent-preload', preloadTasks)
+  } else {
+    ipcRenderer.send('webtorrent-preload', [])
+  }
+  if (client.torrents.length > 100) {
+    client.maxConns = Math.min(client.maxConns, 5)
+    queueTimeout(updateTorrent, 2000)
+  } else queueTimeout(updateTorrent, 1000)
+}
+queueTimeout(updateTorrent, 1000)
+
+let queueUpdate = null
+const forceUpdateTorrent = () => {
+  if (queueUpdate) {
+    clearTimeout(queueUpdate)
+    queueUpdate = setTimeout(() => {
+      queueUpdate = null
+      updateTorrent(true)
+    }, 100)
+  }
+}
+
+const onDone = (tr) => {
+  setTimeout(() => {
+    if (isMac && tr.files && tr.files.length) {
+      tr.files.forEach(file => {
+        const attrs = listAttributesSync(file.path)
+        if (attrs && attrs.includes('com.apple.progress.fractionCompleted')) {
+          console.log(`[Done] Set file progress to 1. ${file.path}`)
+          removeAttributeSync(file.path, 'com.apple.progress.fractionCompleted', '1')
+        }
+      })
+    }
+  }, 1000)
+  if (tr.upload) return console.log('skip upload')
+  tr.isSeeding = true
+  const json = torrentToJson(tr)
+  if (!tr.completedTime) tr.completedTime = Date.now()
+  ipcRenderer.send('webtorrent-done', json)
+  ipcRenderer.send('webtorrent-finish-all-payments', json)
+}
+/** @param { RawTorrent } tr */
+const onReady = (tr) => {
+  tr.files.forEach(/** @param { import('webtorrent/lib/file') } f */f => {
+    // BitComet 0.85+ uses these files itself but will never seed them,
+    // We just ignore them since we can do nothing to them.
+    if (f.name.match(/^_____padding_file_(.*)____$/)) {
+      info('deselect', f.name)
+    }
+    if (isMac && f.path) {
+      setUtimes(f)
+    }
+  })
+  const json = torrentToJson(tr)
+  info('ready', json)
+  ipcRenderer.send('webtorrent-ready', json)
+  if (startServerInfoHash === json.infoHash) {
+    startServer(json.infoHash, json)
+    startServerInfoHash = ''
+  }
+  // diskusage.check(tr.path, (err, result) => {
+  //   if (err) warn(err)
+  //   else {
+  //     const { free } = result
+  //     if (tr.length - tr.downloaded > free + 100_000_000) {
+  //       ipcRenderer.send('webtorrent-no-space', json)
+  //       stopTorrent(tr.infoHash)
+  //     }
+  //   }
+  // })
+  if (client.torrents.filter(i => !i.ready).length === 0) {
+    info('All torrents are ready')
+  }
+}
+const onMetadata = (tr, conf) => {
+  // info('metadata', torrentToJson({ ...conf, ...tr }))
+  ipcRenderer.send('webtorrent-metadata', tr.infoHash)
+  ipcRenderer.send('webtorrent-data', torrentToJson(tr))
+}
+const onWire = (wire, tr, abProtocol) => {
+  wire.use(abProtocol)
+  if (wire.type === 'webrtc') {
+    // info('onwire', wire.remoteAddress, wire.peerId)
+    const setAddress = () => {
+      if (wire.remoteAddress) return
+      const peer = tr._peers[wire.peerId]
+      if (!peer) return setTimeout(setAddress, 1000)
+      const address = peer.conn?._pc?.currentRemoteDescription?.sdp?.match(/c=IN\sIP\d\s(.*)/)?.[1]
+      if (!address) return setTimeout(setAddress, 1000)
+      wire.remoteAddress = address
+    }
+    setAddress()
+  }
+}
+const onInfoHash = (infoHash, tr, conf, isSeeding) => {
+  info('infoHash', infoHash)
+  while (shouldDelete.includes(infoHash)) {
+    shouldDelete.splice(shouldDelete.indexOf(infoHash), 1)
+  }
+  if (infoHashes.includes(infoHash)) {
+    if (client.get(infoHash) !== tr) {
+      info('Destroy tr')
+      ipcRenderer.send('webtorrent-existed', infoHash)
+      tr.destroy()
+    } else {
+      ipcRenderer.send('webtorrent-infohash', infoHash, { ...conf, isSeeding })
+    }
+  } else ipcRenderer.send('webtorrent-infohash', infoHash, { ...conf, isSeeding })
+  infoHashes.push(infoHash)
+  forceUpdateTorrent()
+}
+/**
+ * @function addListeners
+ * @param { Torrent } tr
+ * @param { TorrentInfo } conf
+ * @param { boolean } isSeeding
+ */
+const addListeners = (tr, conf = {}, isSeeding = false) => {
+  if (!conf) conf = {}
+  tr.pending = false
+  tr.removeAllListeners()
+  tr.setMaxListeners(0)
+  info(`Add listeners to torrent ${tr.infoHash || tr.token || tr.origin}`)
+  // tr.on('download', throttle(() => {
+  //   ipcRenderer.send('webtorrent-data', torrentToJson(tr))
+  // }))
+  tr.on('done', () => onDone(tr))
+  tr.on('ready', () => onReady(tr))
+  tr.on('metadata', () => onMetadata(tr, conf))
+  tr.on('infoHash', infoHash => {
+    onInfoHash(infoHash, tr, conf, isSeeding)
+  })
+  tr.on('warning', () => {})
+  tr.on('error', e => {
+    console.log('Torrent error', e, conf)
+    ipcRenderer.send('webtorrent-error', torrentToJson(tr), e.message)
+  })
+  const abProtocol = useAlphabizProtocol(client, tr)
+  tr.on('wire', wire => onWire(wire, tr, abProtocol))
+  tr.on('discovery', () => {
+    if (tr.discovery) {
+      info('start discovery')
+      tr.trackerMap = new TrackerMap()
+      // init map
+      tr.discovery._announce.forEach(url => {
+        verbose('Discovered', url)
+        tr.trackerMap.set(url, { status: 'connecting' })
+        if (!url.startsWith('ws')) {
+          if (url.match(/(\d{1,3}\.){3}\d{1,3}/)) {
+            // ipv4 only
+            return
+          }
+          tr.trackerMap.set(url + '@6', { status: 'connecting' })
+        }
+      })
+      tr.discovery.tracker.on('warning', (error, url, family) => {
+        verbose('tracker warning', url, error.message, family)
+        if (!url) return console.warn('No emitted url', error)
+        if (family === 6) {
+          // info('ipv6 tracker error', url)
+          url = url + '@6'
+        }
+        tr.trackerMap.set(url, {
+          status: 'error',
+          message: utils.parseTrackerWarning(error.message)
+        })
+      })
+      // tr.discovery.tracker.on('peer', (...args) => {
+      //   info('tracker peer', args)
+      // })
+      tr.discovery.tracker.on('update', (info, url, family) => {
+        verbose('tracker update', url, info)
+        if (!url) return console.warn('No emitted url', info)
+        if (family === 6) {
+          // info('ipv6 tracker', url)
+          url = url + '@6'
+        }
+        tr.trackerMap.set(url, {
+          status: 'updated',
+          info
+        })
+      })
+      // tr.discovery.tracker.on('scrape', (...args) => {
+      //   info('tracker scrape', args)
+      // })
+      // tr.addTracker = url => utils.addTracker(tr, url)
+      // tr.removeTracker = url => utils.removeTracker(tr, url)
+      if (conf.customTrackers) {
+        for (const tracker of conf.customTrackers) {
+          addTracker(tr, tracker)
+        }
+      }
+    } else {
+      info('no discovery')
+    }
+  })
+}
+/**
+ * @param { string } token
+ * @param { TorrentInfo } conf
+ * @param { Function } [cb]
+ */
+const addTorrent = (token, conf, cb) => {
+  verbose('Add torrent', token, conf)
+  if (conf.isSeeding && conf.progress === 1) return seedTorrent(token, conf.file, conf)
+  if (conf.infoHash) {
+    const matched = conf.infoHash.match(/btih:([^&]*)/)
+    const _hash = (matched && matched[1]) || conf.infoHash
+    if (_hash && client.get(_hash)) {
+      info('exist', client.get(_hash))
+      return ipcRenderer.send('webtorrent-existed', _hash)
+    }
+  }
+  if (conf.origin) {
+    if (locked.has(conf.origin)) {
+      info('origin lock', conf.origin)
+      return locked.delete(conf.origin)
+    } else {
+      locked.add(conf.origin)
+    }
+  }
+  if (conf.token !== conf.origin) {
+    if (locked.has(conf.token)) {
+      info('token lock', conf.token)
+      info(locked)
+      return locked.delete(conf.token)
+    } else {
+      locked.add(conf.token)
+    }
+  }
+  const add = () => {
+    const torrentId = (conf.torrentPath && fs.existsSync(conf.torrentPath))
+      ? conf.torrentPath
+      : fs.existsSync(conf.token || conf.origin)
+        ? conf.token || conf.origin
+        : conf.infoHash
+    info(torrentId)
+    const tr = client.add(torrentId, {
+      path: conf.path || conf.downloadDirectory,
+      store: FSChunkStore,
+      storeOpts: {
+        postTitle: conf.postTitle || ''
+      },
+      storeCacheSlots: 1,
+      strategy: 'sequential',
+      maxWebConns: client.maxConns,
+      // skipVerify: true,
+      announce: [...(conf.trackers || []), ...WEBTORRENT_ANNOUCEMENT]
+    })
+    tr.token = token
+    tr.origin = conf.infoHash || conf.token || conf.origin
+    tr.createdTime = conf.createdTime || Date.now()
+    tr.usedTime = conf.usedTime || 0
+    if (conf.fromPost) tr.fromPost = conf.fromPost
+    if (conf.postTitle) tr.postTitle = conf.postTitle
+    if (conf.name) tr.name = conf.name
+    if (conf.subtitleList && conf.subtitleList.length) tr.subtitleList = conf.subtitleList
+    verbose('Torrent conf', tr)
+    addListeners(tr, conf)
+    verbose('Listener added')
+    tr.once('infoHash', () => {
+      locked.delete(conf.origin)
+      locked.delete(tr.infoHash)
+      locked.delete(conf.token)
+      if (cb) cb(tr)
+    })
+    if (conf.verifiedPieces) {
+      tr.once('metadata', () => {
+        // If torrent is larger than 200MB, skip verifying downloaded
+        // pieces. This makes webtorrent init much more faster.
+        // It is dangerous, but useful if we add so many torrents.
+        if (tr.length < 200_000_000) return
+        let ctr = 0
+        // Defaultly verify 20% of downloaded pieces
+        let rate = 0.2
+        // 10% if larger than 5G
+        if (tr.length > 5_000_000_000) rate = 0.1
+        // 5% if larger than 20G
+        if (tr.length > 20_000_000_000) rate = 0.05
+        if (tr.length > 50_000_000_000) rate = 0.01
+        if (tr.length > 100_000_000_000) rate = 0.005
+        conf.verifiedPieces.forEach(range => {
+          // tr._markVerified(index)
+          // If range is an array of [start, end]
+          if (Array.isArray(range)) {
+            const [start, end] = range
+            // The first and last pieces are verified. But for security
+            // reason, we skip these pieces in range.
+            for (let i = start + 1; i < end - 1; i++) {
+              // Randomly verify parts of downloaded pieces
+              // if (Math.random() > rate) tr._markVerified(i)
+              tr._markVerified(i)
+              ctr++
+            }
+          } else {
+            if (!isNaN(range)) {
+              tr._markVerified(range)
+              ctr++
+            }
+          }
+        })
+        info('mark verified', conf.verifiedPieces, ctr)
+      })
+    }
+  }
+  if (client.get(conf.infoHash)) {
+    client.remove(conf.infoHash, add)
+  } else if (client.torrents.some(torrent => torrent.token === token)) {
+    const tr = client.torrents.find(torrent => torrent.token === token)
+    if (tr) {
+      if (tr.infoHash) return cb && cb(tr)
+      tr.once('infoHash', () => cb && cb(tr))
+    } else {
+      return add()
+    }
+  } else add()
+}
+/** @param { string } infoHash */
+const stopTorrent = infoHash => {
+  if (locked.has(infoHash)) return
+  else locked.add(infoHash)
+  if (server && serverInfoHash === infoHash) {
+    server.destroy()
+    server = null
+    serverInfoHash = ''
+  }
+  const tr = client.get(infoHash)
+  if (tr && (tr.isSeeding || tr.done)) {
+    tr.completed = true
+  }
+  if (tr) {
+    ipcRenderer.send('webtorrent-finish-all-payments', torrentToJson(tr))
+    tr.destroy(() => {
+      locked.delete(infoHash)
+      ipcRenderer.send('webtorrent-stop', infoHash, tr.completed)
+    })
+  } else {
+    locked.delete(infoHash)
+    if (infoHash) {
+      const _tr = client.torrents.find(tr => tr.token === infoHash)
+      if (_tr) {
+        _tr.destroy(() => {
+          locked.delete(infoHash)
+          ipcRenderer.send('webtorrent-stop', infoHash, _tr.completed)
+        })
+      }
+    } else {
+      ipcRenderer.send('webtorrent-notfound', infoHash)
+    }
+  }
+  if (infoHashes.includes(infoHash)) {
+    infoHashes.splice(infoHashes.indexOf(infoHash), 1)
+  }
+  forceUpdateTorrent()
+}
+/**
+ * @param { string } infoHash
+ * @param { boolean } destroyStore
+ * @param { () => void } onDeleted
+ */
+const deleteTorrent = (infoHash, destroyStore, onDeleted) => {
+  if (locked.has(infoHash)) return
+  else locked.add(infoHash)
+  shouldDelete.push(infoHash)
+  if (server && serverInfoHash === infoHash) {
+    server.destroy()
+    server = null
+    serverInfoHash = ''
+  }
+  const tr = client.get(infoHash) || client.torrents.find(t => t.token === infoHash)
+  info('delete', infoHash, tr, destroyStore)
+  if (tr) {
+    tr.emit('deleted')
+    info('emit', tr.emit)
+    const filePaths = tr.files.length ? tr.files.map(i => i.path) : tr.file || []
+    const publicPath = getPublicPath(filePaths)
+    tr.destroy({ destroyStore }, () => {
+      if (typeof onDeleted === 'function') onDeleted()
+      if (destroyStore) {
+        ipcRenderer.send('webtorrent-delete', tr.infoHash || infoHash, publicPath, filePaths)
+      } else {
+        ipcRenderer.send('webtorrent-delete', tr.infoHash || infoHash)
+      }
+      locked.delete(infoHash)
+      try {
+        client.remove(tr.infoHash)
+      } catch (_) { }
+    })
+  } else {
+    locked.delete(infoHash)
+    ipcRenderer.send('webtorrent-notfound', infoHash)
+  }
+  while (infoHashes.includes(infoHash)) {
+    infoHashes.splice(infoHashes.indexOf(infoHash), 1)
+  }
+  forceUpdateTorrent()
+}
+/**
+ * @param { string } token
+ * @param { string[] } files
+ * @param { TorrentInfo } options
+ * @param { boolean } isAutoUpload
+ * @param { function } callback
+ */
+const seedTorrent = (token, files, options, isAutoUpload = false, callback = null) => {
+  if (options.infoHash && client.get(options.infoHash)) return info('skip existed', options.infoHash)
+  const _torrentId = options.infoHash || options.token || options.origin || (Array.isArray(files) ? files[0] : files)
+  if (_torrentId) {
+    if (locked.has(_torrentId)) return
+    else locked.add(_torrentId)
+  }
+  let tr = null
+  const announce = [...(options.trackers || []), ...WEBTORRENT_ANNOUCEMENT]
+  const seedOpts = {
+    ...options,
+    store: FSChunkStore,
+    storeOpts: {
+      postTitle: options.postTitle || ''
+    },
+    storeCacheSlots: 1,
+    strategy: 'sequential',
+    maxWebConns: client.maxConns,
+    announce
+  }
+  if (options.infoHash && !options.upload && options.files.length) {
+    info('[seed] add torrent with token')
+    info(options)
+    tr = client.add(options.infoHash || options.token || options.origin, Object.assign(seedOpts, {
+      path: options.path || options.downloadDirectory,
+      skipVerify: options.progress === 1
+    }))
+  } else if (options.isSeeding && options.torrentPath && fs.existsSync(options.torrentPath)) {
+    info('[seed] add torrent with torrentPath')
+    tr = client.add(options.torrentPath, Object.assign(seedOpts, {
+      path: options.path || options.downloadDirectory,
+      skipVerify: true
+    }))
+  } else if (options.isSeeding && options.magnetURI && !options.isUploadByFiles) {
+    info('[seed] add torrent with magnetURI')
+    tr = client.add(options.magnetURI, Object.assign(seedOpts, {
+      path: options.path || options.downloadDirectory,
+      skipVerify: true
+    }))
+    tr.upload = true
+    tr.isSeeding = true
+  } else {
+    info('[seed] Seed torrent with files', !!options.infoHash, options)
+    const uploadTasks = client.torrents.filter(tr => tr.progress === 1)
+    const uploadingFiles = uploadTasks.reduce((all, tr) => {
+      const files = tr.files.map(f => f.path)
+      all.push(...files)
+      return all
+    }, [])
+    if (files.some(file => {
+      return uploadingFiles.includes(file)
+    })) {
+      ipcRenderer.send('webtorrent-seed-error', 'task_exists')
+    }
+    tr = client.seed(files, Object.assign(seedOpts, {
+      skipVerify: !!options.infoHash,
+      onProgress (current, total) {
+        // info('onprogress', current, total, current / total)
+        tr.verifyStatus = { current, total }
+      }
+    }))
+    tr.isUploadByFiles = true
+  }
+  info('seedTorrent', options, tr, files)
+  if (options.name) tr.name = options.name
+  tr.isAutoUpload = isAutoUpload
+  tr.token = token
+  tr.isSeeding = true
+  tr.upload = true
+  tr.paused = false
+  tr.file = files
+  tr.createdTime = options.createdTime || Date.now()
+  addListeners(tr, options, true)
+  tr.once('infoHash', () => {
+    locked.delete(_torrentId)
+    if (callback) callback()
+  })
+  tr.once('metadata', () => {
+    ipcRenderer.send('webtorrent-seed', torrentToJson(tr))
+  })
+  // The torrent to seed may computing hashes after torrent deleted
+  tr.once('deleted', () => {
+    // info('torrent deleted')
+    if (seedOpts.onProgress) {
+      seedOpts.onProgress._destroyed = true
+    }
+  })
+  return tr
+}
+
+const getTorrent = () => {
+  const torrents = client.torrents.map(i => torrentToJson(i))
+  info(torrents)
+  return ipcRenderer.send('webtorrent-list', torrents)
+}
+
+/**
+ * @param { Object } conf
+ * @param { 'low'|'mid'|'high' } conf.level
+ */
+const setThrottleGroup = ({ infoHash, peerId, subId, level }) => {
+  const tr = client.get(infoHash)
+  if (!tr) {
+    info('not found', infoHash)
+    ipcRenderer.send('webtorrent-set-throttle', {
+      code: -1,
+      message: 'Torrent Not Found'
+    })
+    return null
+  }
+  let peer = null, error = null
+  for (const wire of tr.wires) {
+    if (subId ? wire.remoteSub === subId : wire.peerId === peerId) {
+      peer = wire
+      try {
+        wire._setThrottleGroup(level)
+      } catch (e) {
+        error = { code: -1, message: e.message }
+      }
+      break
+    }
+  }
+  if (!peer) {
+    ipcRenderer.send('webtorrent-set-throttle', {
+      code: -1,
+      message: 'Peer Not Found'
+    })
+  } else if (error) ipcRenderer.send('webtorrent-set-throttle', error)
+  else {
+    ipcRenderer.send('webtorrent-set-throttle', {
+      code: 0,
+      message: 'success'
+    })
+  }
+  return peer
+}
+const saveTorrentFile = (infoHash, dir) => {
+  const channel = 'webtorrent-save-torrent'
+  const tr = client.get(infoHash)
+  if (!tr) return
+  if (!tr.torrentFile || !tr.name) {
+    return ipcRenderer.send(channel, {
+      code: -1,
+      message: 'Torrent Not Ready'
+    })
+  }
+  let torrentPath
+  try {
+    torrentPath = saveTorrentByName(dir, tr.name, tr.torrentFile)
+  } catch (error) {
+    info('Refused to save torrent metadata', error)
+    return ipcRenderer.send(channel, {
+      code: -1,
+      message: 'Unable to save torrent metadata safely',
+      infoHash
+    })
+  }
+  ipcRenderer.send(channel, {
+    code: 0,
+    message: 'success',
+    infoHash,
+    torrentPath
+  })
+}
+
+/** @type { ReturnType<import('webtorrent/lib/server')>} */
+let server = null
+let serverInfoHash = ''
+/** @param { Torrent } tr */
+const startTorrentServer = tr => {
+  info('Start server', tr)
+  startServerInfoHash = ''
+  if (server) {
+    // should stop old server and start a new one
+    if (serverInfoHash === tr.infoHash) {
+      return ipcRenderer.send('webtorrent-server-ready', tr.infoHash, {
+        token: tr.token,
+        port: server.address().port
+      })
+    } else {
+      server.destroy()
+      server = null
+      serverInfoHash = ''
+    }
+  }
+  info('Create server', tr)
+  server = tr.createServer()
+  server.listen(0, () => {
+    const port = server.address().port
+    const info = {
+      token: tr.token,
+      port
+    }
+    ipcRenderer.send('webtorrent-server-ready', tr.infoHash, info)
+    const sendProgress = () => {
+      const progress = tr.files.map(f => {
+        const prog = []
+        for (let i = f._startPiece; i < f._endPiece; i++) {
+          prog.push(tr.pieces[i] === null ? 1 : 0)
+        }
+        return {
+          name: f.name,
+          path: f.path,
+          progress: prog
+        }
+      })
+      ipcRenderer.send('webtorrent-server-progress', tr.infoHash, progress)
+    }
+    setTimeout(sendProgress, 1000)
+    // We don't need to update progress very frequently, 5s is enough
+    const inter = setInterval(sendProgress, 5000)
+    server.once('close', () => clearInterval(inter))
+  })
+}
+const startServer = (infoHash, conf) => {
+  info('start server', infoHash, conf)
+  startServerInfoHash = infoHash
+  const tr = client.get(infoHash)
+  if (!tr) {
+    return addTorrent(conf.token || conf.infoHash, conf, () => {
+      return startServer(infoHash, conf)
+    })
+  }
+  if (tr.ready) {
+    info('tr ready. start server')
+    startTorrentServer(tr, conf)
+  } else {
+    tr.once('ready', () => startTorrentServer(tr, conf))
+  }
+}
+const stopServer = () => {
+  if (!server) return
+  server.destroy()
+  server = null
+  serverInfoHash = ''
+  info('Destroy server')
+}
+
+(function init () {
+  ipcRenderer.once('redirect-log', (e, logPath) => {
+    console.log('Write webtorrent logs to', logPath)
+    utils.useRedirectLogs(logPath)
+  })
+  ipcRenderer.on('add-torrent', (e, token, torrentInfo) => {
+    if (torrentInfo.magnetURI && !torrentInfo.torrentPath) {
+      const preloaded = preloader.loadCache(torrentInfo.magnetURI, torrentInfo.path)
+      if (preloaded) {
+        console.log('[Preload] Load cached task', preloaded)
+        torrentInfo.torrentPath = preloaded
+      } else {
+        console.log('Cannot find preloaded task for', torrentInfo)
+      }
+    }
+    return addTorrent(token, torrentInfo)
+  })
+  ipcRenderer.on('stop-torrent', (e, infoHash) => {
+    console.log('got stop', infoHash)
+    return stopTorrent(infoHash)
+  })
+  ipcRenderer.on('stop-all-uploading', (e, torrents) => {
+    torrents.forEach(tr => {
+      const t = client.torrents.find(i => {
+        if (i.infoHash && i.infoHash === tr.infoHash) return true
+        if (i.token && i.token === tr.token) return true
+        return false
+      })
+      if (t) t.destroy()
+    })
+  })
+  ipcRenderer.on('delete-all', (e, type, destroyStore, deleteAutoUpload) => {
+    shouldSendInfo = false
+    info('Delete all', type, destroyStore, deleteAutoUpload)
+    const toDeletes = client.torrents.filter(tr => {
+      if (type === 'all') return true
+      const isUpload = tr.upload || tr.progress === 1 || tr.isSeeding
+      if (type === 'upload') {
+        if (!deleteAutoUpload && tr.isAutoUpload) return false
+        return isUpload
+      }
+      return !isUpload
+    })
+    if (!toDeletes.length) {
+      shouldSendInfo = true
+      return
+    }
+    // ensure all torrents are deleted
+    let end = 0
+    toDeletes.forEach(tr => {
+      end++
+      info(tr.infoHash)
+      shouldDelete.push(tr.infoHash)
+      tr.removeAllListeners()
+      try {
+        deleteTorrent(tr.infoHash, destroyStore, () => {
+          if (shouldDelete.includes(tr.infoHash)) {
+            shouldDelete.splice(shouldDelete.indexOf(tr.infoHash), 1)
+          }
+          end--
+          if (end === 0) shouldSendInfo = true
+        })
+      } catch (e) { }
+    })
+    // avoid something go wrong
+    setTimeout(() => {
+      shouldSendInfo = true
+    }, 2000)
+  })
+  ipcRenderer.on('seed-torrent', (e, torrentInfo) => {
+    let { file, token, ...options } = torrentInfo
+    // for downloaded torrents
+    if (!file) file = torrentInfo.files.map(i => i.path)
+    console.log(torrentInfo)
+    if (!file.length) return ipcRenderer.send('seed-error')
+    if (!token) token = Math.random().toString().substr(2)
+    return seedTorrent(token, file, options)
+  })
+  ipcRenderer.on('seed-torrents', (e, confs) => {
+    info(`Seed ${confs.length} torrents`)
+    confs.forEach(conf => {
+      let { file, token, ...options } = conf
+      if (!file) file = conf.files.map(i => i.path)
+      if (!token) token = Math.random().toString().substring(2)
+      seedTorrent(token, file, { ...conf })
+    })
+  })
+  ipcRenderer.on('autoupload-files', async (e, files) => {
+    info('autoupload files', files)
+    Promise.all(files.map(file => {
+      info('Auto upload', file)
+      // if file is already uploaded, ignore it
+      if (client.torrents.some(/** @param { Torrent } tr */tr => {
+        return tr.files.some(f => {
+          return f.path === file
+        }) || (tr.file && tr.file.some && tr.file.some(f => f === file)) || tr.file === file
+      })) {
+        info(`${file} is already uploaded, skipped`)
+        return
+      }
+      return new Promise(resolve => {
+        seedTorrent(
+          'autoupload-' + path.basename(file),
+          [file],
+          { path: path.dirname(file) },
+          true,
+          resolve
+        )
+      })
+    })).then(() => {
+      info('autoupload complete')
+      ipcRenderer.send('autoupload-complete')
+    }).catch((error) => {
+      ipcRenderer.send('autoupload-complete', error.message || error)
+    })
+    // Call tr#destroy in torrents.forEach may cause undefined behavior
+    // since tr#destory will remove it from torrents
+    // Save references before destroy them
+    const toDestroy = []
+    client.torrents.forEach(/** @param { Torrent } tr */ tr => {
+      if (tr.isAutoUpload && tr.ready) {
+        if (!tr.files.some(f => files.includes(f.path))) {
+          // remove deleted file
+          info(`${tr.infoHash} has been deleted. Destroy`, tr.files.map(i => i.path))
+          // tr.destroy(() => {
+          //   ipcRenderer.send('webtorrent-delete', tr.infoHash)
+          // })
+          toDestroy.push(tr)
+        } else {
+          info(`${tr.infoHash} is kept alive`)
+        }
+      }
+    })
+    toDestroy.forEach(tr => {
+      tr.destroy(() => {
+        ipcRenderer.send('webtorrent-delete', tr.infoHash)
+      })
+    })
+  })
+  ipcRenderer.on('start-server', (e, { infoHash, conf }) => {
+    info('start server', infoHash, conf)
+    return startServer(infoHash, conf)
+  })
+  ipcRenderer.on('stop-server', () => stopServer())
+  ipcRenderer.on('delete-torrent', (e, infoHash, destroyStore) => {
+    return deleteTorrent(infoHash, destroyStore)
+  })
+  ipcRenderer.on('pend-torrent', (e, conf) => {
+    const tr = client.get(conf.infoHash)
+    if (infoHashes.includes(conf.infoHash)) {
+      infoHashes.splice(infoHashes.indexOf(conf.infoHash), 1)
+    }
+    info('Pend', conf.infoHash, tr)
+    if (tr) {
+      tr.removeAllListeners()
+      tr.destroy()
+      tr.pending = true
+      ipcRenderer.send('webtorrent-pending', torrentToJson(tr))
+    }
+  })
+  ipcRenderer.on('set-throttle-group', (e, { infoHash, peerId, subId, level }) => {
+    info(infoHash, peerId, subId, level)
+    setThrottleGroup({ infoHash, peerId, subId, level })
+  })
+  ipcRenderer.on('save-torrent-file', (e, infoHash, dir) => saveTorrentFile(infoHash, dir))
+  ipcRenderer.on('update-settings', (e, {
+    uploadSpeed,
+    downloadSpeed,
+    maximumConnectionsNum,
+    DHTlistenPort,
+    BTlistenPort,
+    payedUserShareRate,
+    secureOption,
+    libraryPreload,
+    showPreload
+  }) => {
+    // old versions use string, but now number
+    const dhtPort = parseInt(DHTlistenPort)
+    const torrentPort = parseInt(BTlistenPort)
+    info('Set client', {
+      uploadSpeed,
+      downloadSpeed,
+      maximumConnectionsNum,
+      dhtPort,
+      torrentPort,
+      payedUserShareRate,
+      secureOption,
+      libraryPreload,
+      showPreload
+    })
+    if (payedUserShareRate) {
+      const shareRate = Number(payedUserShareRate) || 0.7
+      localStorage.setItem('payedUserShareRate', shareRate.toString())
+    }
+    if (uploadSpeed) {
+      const limit = speedLimit(uploadSpeed)
+      localStorage.setItem('uploadSpeed', limit.toString())
+    }
+    const shareRate = Number(localStorage.getItem('payedUserShareRate')) || 0.7
+    const limit = parseInt(localStorage.getItem('uploadSpeed'))
+    if (!isNaN(shareRate) && !isNaN(limit)) {
+      if (limit === -1) client.throttleUpload(-1)
+      else client.throttleUpload(limit, shareRate)
+    }
+    if (downloadSpeed) {
+      const limit = speedLimit(downloadSpeed)
+      client.throttleDownload(limit)
+      localStorage.setItem('downloadSpeed', limit.toString())
+    }
+    if (maximumConnectionsNum) {
+      client.maxConns = maximumConnectionsNum
+      localStorage.setItem('maximumConnectionsNum', maximumConnectionsNum.toString())
+    }
+    let shouldRestart = false
+    if (dhtPort && dhtPort !== parseInt(localStorage.getItem('dhtPort'))) {
+      shouldRestart = true
+      localStorage.setItem('dhtPort', dhtPort.toString())
+    }
+    if (torrentPort && torrentPort !== parseInt(localStorage.getItem('torrentPort'))) {
+      shouldRestart = true
+      localStorage.setItem('torrentPort', torrentPort.toString())
+    }
+    if (typeof secureOption === 'string') {
+      localStorage.setItem('webtorrent-secure', secureOption)
+      setSecure(secureOption)
+      info('set secure', secureOption)
+    }
+    if (shouldRestart) {
+      // process.exit(0)
+      // process.exit makes devtools unaccessable, use reload instead
+      location.reload()
+    }
+    // Preload config
+    // `libraryPreload` may be `undefined` if user did not change it at this time
+    if (libraryPreload === true) preloader.enable()
+    else if (libraryPreload === false) preloader.disable()
+    // `showPreload` may be `undefined` that should not update `sendPreloadTasks`
+    if (showPreload === true) {
+      sendPreloadTasks = true
+      localStorage.setItem('send-preload-tasks', '1')
+    } else if (showPreload === false) {
+      sendPreloadTasks = false
+      localStorage.setItem('send-preload-tasks', '0')
+    }
+  })
+  ipcRenderer.on('reset-torrent', () => {
+    info('reset')
+    shouldSendInfo = false
+    Promise.all(client.torrents.map(tr => new Promise(resolve => {
+      tr.removeAllListeners()
+      tr.destroy({ destroyStore: true }, resolve)
+    })))
+      .then(() => ipcRenderer.send('webtorrent-reset'))
+      .catch(() => ipcRenderer.send('webtorrent-reset-error'))
+      .finally(() => {
+        info('resetted')
+        client.torrents.length = 0
+        shouldSendInfo = true
+      })
+  })
+  ipcRenderer.on('add-tracker', (e, { infoHash, url }) => {
+    info('add-tracker', infoHash, url)
+    addTracker(infoHash, url)
+  })
+  ipcRenderer.on('remove-tracker', (e, { infoHash, url }) => {
+    info('remove-tracker', infoHash, url)
+    removeTracker(infoHash, url)
+  })
+  ipcRenderer.on('force-exit', () => process.exit(0))
+  setInterval(() => {
+    if (process.memoryUsage().rss / 1_000_000_000 > 3.5) {
+      info('exit for memory reason')
+      process.exit(0)
+    }
+  }, 60000)
+
+  initClient(0)
+  // ipcRenderer.send('webtorrent-initted')
+  window.addEventListener('error', e => {
+    info(e.message || e)
+    // ipcRenderer.send('webtorrent-window-error', e.error && e.error.message || e.message)
+    return true
+  })
+  ipcRenderer.on('before-quit', () => {
+    natPorts.forEach(port => {
+      natTraversal.portUnMapping(port)
+    })
+  })
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', () => {
+      natPorts.forEach(port => {
+        natTraversal.portUnMapping(port)
+      })
+    })
+  }
+})()

--- a/dist/spa/torrent-file.js
+++ b/dist/spa/torrent-file.js
@@ -1,0 +1,121 @@
+(() => {
+  'use strict'
+
+  const crypto = require('crypto')
+  const fs = require('fs')
+  const path = require('path')
+
+  const INFO_HASH_PATTERN = /^(?:[a-f\d]{40}|[a-f\d]{64})$/i
+
+  function writeUniqueSibling (filePath, contents) {
+    const parsedPath = path.parse(filePath)
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const suffix = crypto.randomBytes(8).toString('hex')
+      const candidate = path.join(
+        parsedPath.dir,
+        `${parsedPath.name}.${suffix}${parsedPath.ext}`
+      )
+      try {
+        fs.writeFileSync(candidate, contents, { flag: 'wx', mode: 0o600 })
+        return candidate
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error
+      }
+    }
+    throw new Error('Unable to create a unique torrent file')
+  }
+
+  function writeFileOnce (filePath, torrentFile) {
+    const contents = Buffer.from(torrentFile)
+    try {
+      fs.writeFileSync(filePath, contents, { flag: 'wx', mode: 0o600 })
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error
+
+      let existingFd
+      try {
+        const noFollow = fs.constants.O_NOFOLLOW
+        if (!noFollow) {
+          return writeUniqueSibling(filePath, contents)
+        }
+        existingFd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow)
+        if (!fs.fstatSync(existingFd).isFile()) {
+          throw new Error(`Refusing to use a non-regular torrent file: ${filePath}`)
+        }
+        if (!fs.readFileSync(existingFd).equals(contents)) {
+          throw new Error(`Refusing to replace a different torrent file: ${filePath}`)
+        }
+      } finally {
+        if (existingFd !== undefined) fs.closeSync(existingFd)
+      }
+    }
+    return filePath
+  }
+
+  function prepareDirectory (directory) {
+    const resolvedDirectory = path.resolve(directory)
+    fs.mkdirSync(resolvedDirectory, { recursive: true, mode: 0o700 })
+    const realDirectory = fs.realpathSync(resolvedDirectory)
+    if (!fs.statSync(realDirectory).isDirectory()) {
+      throw new Error(`Expected a torrent directory: ${resolvedDirectory}`)
+    }
+    return realDirectory
+  }
+
+  function saveTorrentByInfoHash (directory, infoHash, torrentFile) {
+    const normalizedInfoHash = String(infoHash).toLowerCase()
+    if (!INFO_HASH_PATTERN.test(normalizedInfoHash)) {
+      throw new Error('Invalid torrent info hash')
+    }
+    const resolvedDirectory = prepareDirectory(directory)
+    return writeFileOnce(
+      path.join(resolvedDirectory, `${normalizedInfoHash}.torrent`),
+      torrentFile
+    )
+  }
+
+  function sanitizeTorrentName (name) {
+    let safeName = String(name)
+      .replace(/[\u0000-\u001f\u007f<>:"/\\|?*]/g, '_')
+      .replace(/^\.+/, '_')
+      .replace(/[. ]+$/g, '')
+    if (/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(safeName)) {
+      safeName = `_${safeName}`
+    }
+    let byteLength = 0
+    let truncatedName = ''
+    for (const character of safeName) {
+      const characterBytes = Buffer.byteLength(character, 'utf-8')
+      if (byteLength + characterBytes > 200) break
+      byteLength += characterBytes
+      truncatedName += character
+    }
+    safeName = truncatedName.replace(/[. ]+$/g, '')
+    if (!safeName) throw new Error('Invalid torrent name')
+    return safeName
+  }
+
+  function saveTorrentByName (directory, name, torrentFile) {
+    const resolvedDirectory = prepareDirectory(directory)
+    const torrentPath = path.resolve(
+      resolvedDirectory,
+      `${sanitizeTorrentName(name)}.torrent`
+    )
+    if (path.dirname(torrentPath) !== resolvedDirectory) {
+      throw new Error('Invalid torrent path')
+    }
+    return writeFileOnce(torrentPath, torrentFile)
+  }
+
+  Object.defineProperty(globalThis, 'alphabizTorrentFile', {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: Object.freeze({
+      INFO_HASH_PATTERN,
+      sanitizeTorrentName,
+      saveTorrentByInfoHash,
+      saveTorrentByName
+    })
+  })
+})()

--- a/dist/spa/webtorrent-preload.js
+++ b/dist/spa/webtorrent-preload.js
@@ -1,1 +1,310 @@
-const{ipcRenderer:ipcRenderer}=require("electron"),{existsSync:existsSync,writeFileSync:writeFileSync,readFileSync:readFileSync,mkdirSync:mkdirSync,cpSync:cpSync,statSync:statSync,rmSync:rmSync}=require("fs"),{resolve:resolve,dirname:dirname}=require("path"),WebTorrent=require("webtorrent");import utils from"./webtorrent-utils.js";const{torrentToJson:torrentToJson}=utils,downloadThreshold=3e7,maxWaitTime=6e4,maxTask=5;let maxPreload=20;if("string"===typeof localStorage.getItem("library-max-preload")){const e=Number(localStorage.getItem("library-max-preload"));isNaN(e)||(maxPreload=e)}let storePath="";const preloadClient=new WebTorrent({maxConns:5,downloadLimit:3e6,uploadLimit:3e5}),preloadTasks=new Map,taskQueue=[],previous=[],failures=[];global.preload={client:preloadClient,tasks:preloadTasks,queue:taskQueue};const saveTasks=()=>{if(!storePath)return;existsSync(dirname(storePath))||mkdirSync(dirname(storePath),{recursive:!0});const e=[];for(const[r,t]of preloadTasks.entries())e.push({url:r,...t});writeFileSync(storePath,JSON.stringify(e,null,2))},removeOldIfNeeded=()=>{if(!storePath)return;let e=preloadTasks.size-maxPreload;if(!(e<=0))for(const[r,t]of[...preloadTasks.entries()])if(preloadTasks.delete(r),[t.torrentPath,t.downloadPath].forEach((e=>{"string"===typeof e&&existsSync(e)&&rmSync(e,{recursive:!0})})),console.log("[Preload] Remove old task",r),e--,e<=0)return saveTasks()},queueTask=({url:e,path:r,origin:t,postTitle:o})=>{if(maxPreload<=0)return;if(taskQueue.find((r=>r.url===e)))return console.log("[Preload] Skip existed",e);if(taskQueue.length>=maxTask){const e=taskQueue.shift();if(e){const{url:r,path:t,origin:o,postTitle:s,torrent:a}=e;console.log("[Preload] Remove first old task from queue",r),preloadTasks.has(r)?a.destroy((()=>{})):a.destroy({destroyStore:!0},(()=>{previous.push({url:r,path:t,origin:o,postTitle:s})}))}}let s=!1;const a=preloadClient.add(e,{path:r,storeOpts:{postTitle:o||""},postTitle:o,strategy:"sequential"});taskQueue.push({url:e,path:r,origin:t,postTitle:o,torrent:a});const n=setTimeout((()=>{a.ready||a.destroyed||(console.log("[Preload] Failed to load task",t),ipcRenderer.send("preload-failed",t),a.destroy((()=>{const r=taskQueue.findIndex((r=>r.url===e));if(-1!==r){const[e]=taskQueue.splice(r,1);failures.find((r=>r.origin===e.origin))||failures.push(e)}})))}),maxWaitTime);return a.on("ready",(()=>{if(clearTimeout(n),!a.torrentFile||!a.infoHash)return;const o=resolve(dirname(r),`../torrents/${a.infoHash}.torrent`);existsSync(dirname(o))||mkdirSync(dirname(o),{recursive:!0}),existsSync(o)||writeFileSync(o,a.torrentFile),preloadTasks.has(e)||(preloadTasks.set(e,{downloadPath:r,torrentPath:o,origin:t,torrent:Object.assign(torrentToJson(a),{preloadStatus:1})}),saveTasks())})),a.on("download",(()=>{s||a.downloaded>downloadThreshold&&(s=!0,a.destroy((()=>{console.log("[Preload] Finish preloading",t),removeOldIfNeeded(),ipcRenderer.emit("preload-done",t);const r=taskQueue.findIndex((r=>r.url===e)),o=preloadTasks.get(e);if(o&&(o.torrent=Object.assign(torrentToJson(a),{preloadStatus:2}),saveTasks()),-1!==r&&(taskQueue.splice(r,1),taskQueue.length<maxTask&&previous.length)){const{url:e,path:r,origin:t,postTitle:o}=previous.shift();queueTask({url:e,path:r,origin:t,postTitle:o})}})))})),a};ipcRenderer.on("preload-restore",((e,r)=>{console.log("[Preload] Restore",r);try{const e=resolve(r,"preload-tasks.json"),t=new Date;t.setDate(t.getDate()-7);const o=t.valueOf();if(existsSync(e)){const r=JSON.parse(readFileSync(e));for(const e of r){if(!existsSync(e.torrentPath)||!existsSync(e.downloadPath)){existsSync(e.torrentPath)&&rmSync(e.torrentPath),existsSync(e.downloadPath)&&rmSync(e.downloadPath,{recursive:!0});continue}if(e.removed)continue;const{mtimeMs:r}=statSync(e.torrentPath);r<o?(rmSync(e.torrentPath),existsSync(e.downloadPath)&&rmSync(e.downloadPath,{recursive:!0})):e.torrent&&e.torrent.downloaded<downloadThreshold?(queueTask({url:e.url,origin:e.origin,path:e.downloadPath,postTitle:e.torrent.postTitle||e.torrent.name}),console.log("[Preload] Restart",e.url)):(console.log("[Preload] Restore",e.url),preloadTasks.set(e.url,e))}console.log(`[Preload] Restore ${r.length} tasks`)}storePath=e}catch(e){console.log(`Failed to load preloads from ${r}`,e)}})),ipcRenderer.on("preload-task",((e,{url:r,path:t,origin:o,postTitle:s})=>{preloadTasks.has(r)||(console.log("[Preload] Receive task",{url:r,path:t,origin:o,postTitle:s}),queueTask({url:r,path:t,origin:o,postTitle:s}))}));export default{loadCache(e,r){if(preloadTasks.has(e)){const{torrentPath:t,downloadPath:o,removed:s}=preloadTasks.get(e);return s?(console.log("Preload task is removed!"),t):(console.log("copy",o,r),cpSync(o,r,{recursive:!0}),setTimeout((()=>{rmSync(o,{recursive:!0}),preloadTasks.set(e,{torrentPath:t,removed:!0})}),5e3),t)}return null},enable(){maxPreload=40,localStorage.setItem("library-max-preload","40")},disable(){maxPreload=0,localStorage.setItem("library-max-preload","0"),removeOldIfNeeded(),taskQueue.splice(0),preloadTasks.clear()},preloadTasks:preloadTasks,taskQueue:taskQueue,failures:failures};
+const { ipcRenderer } = require('electron')
+const { existsSync, writeFileSync, readFileSync, mkdirSync, cpSync, statSync, rmSync } = require('fs')
+const { resolve, dirname } = require('path')
+const WebTorrent = require('webtorrent')
+const { saveTorrentByInfoHash } = globalThis.alphabizTorrentFile || {}
+if (typeof saveTorrentByInfoHash !== 'function') {
+  throw new Error('Torrent file security boundary is not loaded')
+}
+import utils from './webtorrent-utils.js'
+const { torrentToJson } = utils
+
+/**
+ * @typedef { import('webtorrent/lib/torrent') } Torrent
+ */
+
+// Currently up to download 30MB for a task
+const downloadThreshold = 30_000_000
+// Wait a torrent for 10 mins to ready
+const maxWaitTime = 60_000
+// Only allow downloading `maxTask` tasks at same time
+const maxTask = 5
+
+// If tasks count is larger than this, remove oldest task from disk
+// Set to 0 and call `removeOldIfNeeded` will remove all preload tasks
+let maxPreload = 20
+// Load config from local storage when launched
+if (typeof localStorage.getItem('library-max-preload') === 'string') {
+  const n = Number(localStorage.getItem('library-max-preload'))
+  if (!isNaN(n)) maxPreload = n
+}
+// Store path
+let storePath = ''
+const preloadClient = new WebTorrent({
+  maxConns: 5,
+  downloadLimit: 3000_000,
+  uploadLimit: 300_000
+})
+
+/**
+ * @typedef PreloadTask
+ * @property { string } torrentPath
+ * @property { string } downloadPath
+ * @property { string } origin
+ * @property { Torrent } torrent
+ */
+/** @type { Map<string, PreloadTask> } a map of all added tasks */
+const preloadTasks = new Map()
+/** @type { { url: string, path: string, origin: string, postTitle: string, torrent: Torrent }[] } a queue of current downloading urls */
+const taskQueue = []
+/** @type { { url: string, path: string, origin: string, postTitle: string }[] } */
+const previous = []
+/** @type { { url: string, path: string, origin: string, postTitle: string, torrent: Torrent }[] } a queue of current downloading urls */
+const failures = []
+
+// For debug
+global.preload = {
+  client: preloadClient,
+  tasks: preloadTasks,
+  queue: taskQueue
+}
+// Save preloaded tasks
+const saveTasks = () => {
+  if (!storePath) return
+  if (!existsSync(dirname(storePath))) mkdirSync(dirname(storePath), { recursive: true })
+  const tasks = []
+  for (const [url, task] of preloadTasks.entries()) {
+    tasks.push({
+      url,
+      ...task
+    })
+  }
+  writeFileSync(storePath, JSON.stringify(tasks, null, 2))
+}
+const removeOldIfNeeded = () => {
+  if (!storePath) return
+  let overStack = preloadTasks.size - maxPreload
+  if (overStack <= 0) return
+  // Use [...entries] to avoid errors when we delete entry from map
+  for (const [url, task] of [...preloadTasks.entries()]) {
+    preloadTasks.delete(url)
+    ;[task.torrentPath, task.downloadPath].forEach(p => {
+      if (typeof p === 'string' && existsSync(p)) rmSync(p, { recursive: true })
+    })
+    console.log('[Preload] Remove old task', url)
+    overStack--
+    // Save result
+    if (overStack <= 0) return saveTasks()
+  }
+}
+
+
+/**
+ * @function queueTask
+ * @param { object } conf
+ * @param { string } conf.url magnet url
+ * @param { string } conf.path preload directory
+ * @param { string } conf.origin origin alphabiz-url
+ * @param { string } conf.postTitle post title
+ * @returns { Torrent }
+ */
+const queueTask = ({ url, path, origin, postTitle }) => {
+  if (maxPreload <= 0) return
+  if (taskQueue.find(i => i.url === url)) return console.log('[Preload] Skip existed', url)
+  if (taskQueue.length >= maxTask) {
+    // Destroy oldest one
+    const task = taskQueue.shift()
+    if (task) {
+      const { url, path, origin, postTitle, torrent } = task
+      console.log('[Preload] Remove first old task from queue', url)
+      /**
+       * If torrent is not ready, all downloaded pieces are not able to be reused.
+       * So we have to remove them all for saving disk space.
+       */
+      if (!preloadTasks.has(url)) {
+        torrent.destroy({ destroyStore: true }, () => {
+          // If anyone of other tasks is completed, we can try restore old tasks from here
+          previous.push({ url, path, origin, postTitle })
+        })
+      } else {
+        torrent.destroy(() => {})
+      }
+    }
+  }
+  let destroying = false
+  const torrent = preloadClient.add(url, {
+    path,
+    storeOpts: {
+      postTitle: postTitle || ''
+    },
+    postTitle,
+    strategy: 'sequential'
+  })
+  taskQueue.push({ url, path, origin, postTitle, torrent })
+  const timer = setTimeout(() => {
+    if (!torrent.ready && !torrent.destroyed) {
+      console.log('[Preload] Failed to load task', origin)
+      // The origin ab-url is used to disable download-and-play button in main process
+      ipcRenderer.send('preload-failed', origin)
+      // Torrent is still pending after a long time. Remove it
+      torrent.destroy(() => {
+        const index = taskQueue.findIndex(i => i.url === url)
+        if (index !== -1) {
+          const [task] = taskQueue.splice(index, 1)
+          if (!failures.find(f => f.origin === task.origin)) failures.push(task)
+        }
+      })
+    }
+  }, maxWaitTime)
+  torrent.on('ready', () => {
+    clearTimeout(timer)
+    if (!torrent.torrentFile || !torrent.infoHash) return
+    const torrentsDir = resolve(dirname(path), '../torrents')
+    let torrentPath
+    try {
+      torrentPath = saveTorrentByInfoHash(
+        torrentsDir,
+        torrent.infoHash,
+        torrent.torrentFile
+      )
+    } catch (error) {
+      console.error('[Preload] Refused to save torrent metadata', error)
+      ipcRenderer.send('preload-failed', origin)
+      return
+    }
+    if (!preloadTasks.has(url)) {
+      preloadTasks.set(url, {
+        downloadPath: path,
+        torrentPath,
+        origin,
+        torrent: Object.assign(
+          torrentToJson(torrent),
+          /**
+           * Preload status
+           * (0) - not a preload task
+           * 1 - downloading
+           * 2 - downloaded
+           */
+          { preloadStatus: 1 }
+        )
+      })
+      saveTasks()
+    }
+  })
+  torrent.on('download', () => {
+    if (destroying) return
+    // Avoid trigger twice
+    if (torrent.downloaded > downloadThreshold) {
+      destroying = true
+      torrent.destroy(() => {
+        console.log('[Preload] Finish preloading', origin)
+        removeOldIfNeeded()
+        ipcRenderer.emit('preload-done', origin)
+        const index = taskQueue.findIndex(i => i.url === url)
+        const old = preloadTasks.get(url)
+        if (old) {
+          // Only update preload status after downloaded
+          old.torrent = Object.assign(
+            torrentToJson(torrent),
+            { preloadStatus: 2 }
+          )
+          saveTasks()
+        }
+        if (index !== -1) {
+          taskQueue.splice(index, 1)
+          if (taskQueue.length < maxTask && previous.length) {
+            const { url, path, origin, postTitle } = previous.shift()
+            queueTask({ url, path, origin, postTitle })
+          }
+        }
+      })
+    }
+  })
+  return torrent
+}
+
+// Restore saved tasks after relaunch
+ipcRenderer.on('preload-restore', (e, path) => {
+  console.log('[Preload] Restore', path)
+  try {
+    const p = resolve(path, 'preload-tasks.json')
+    const now = new Date()
+    now.setDate(now.getDate() - 7)
+    const oneWeekAgo = now.valueOf()
+    if (existsSync(p)) {
+      const tasks = JSON.parse(readFileSync(p))
+      for (const task of tasks) {
+        if (!existsSync(task.torrentPath) || !existsSync(task.downloadPath)) {
+          if (existsSync(task.torrentPath)) rmSync(task.torrentPath)
+          if (existsSync(task.downloadPath)) rmSync(task.downloadPath, { recursive: true })
+          continue
+        }
+        if (task.removed) continue
+        const { mtimeMs } = statSync(task.torrentPath)
+        // Remove old caches
+        if (mtimeMs < oneWeekAgo) {
+          rmSync(task.torrentPath)
+          if (existsSync(task.downloadPath)) rmSync(task.downloadPath, { recursive: true })
+          continue
+        }
+        if (task.torrent && task.torrent.downloaded < downloadThreshold) {
+          // This task was not loaded before
+          queueTask({
+            url: task.url,
+            origin: task.origin,
+            path: task.downloadPath,
+            postTitle: task.torrent.postTitle || task.torrent.name
+          })
+          console.log('[Preload] Restart', task.url)
+        } else {
+          console.log('[Preload] Restore', task.url)
+          preloadTasks.set(task.url, task)
+        }
+      }
+      console.log(`[Preload] Restore ${tasks.length} tasks`)
+    }
+    storePath = p
+  } catch (e) {
+    console.log(`Failed to load preloads from ${path}`, e)
+  }
+})
+ipcRenderer.on('preload-task', (e, { url, path, origin, postTitle }) => {
+  if (!preloadTasks.has(url)) {
+    console.log('[Preload] Receive task', { url, path, origin, postTitle })
+    queueTask({ url, path, origin, postTitle })
+  }
+})
+
+export default {
+  /**
+   * @function loadCache
+   * @param { string } url Torrent url to download
+   * @param { string } downloadDirectory Directory to save downloaded pieces
+   * @returns { string|null } Preloaded torrent file path
+   */
+  loadCache (url, downloadDirectory) {
+    if (preloadTasks.has(url)) {
+      // Copy preloaded files to `downloadDirectory` and return the preloaded torrent file
+      const { torrentPath, downloadPath, removed } = preloadTasks.get(url)
+      if (removed) {
+        console.log('Preload task is removed!')
+        return torrentPath
+      }
+      console.log('copy', downloadPath, downloadDirectory)
+      cpSync(downloadPath, downloadDirectory, { recursive: true })
+      // Remove preloaded task as it is added
+      setTimeout(() => {
+        rmSync(downloadPath, { recursive: true })
+        preloadTasks.set(url, { torrentPath, removed: true })
+      }, 5000)
+      return torrentPath
+    }
+    return null
+  },
+  enable () {
+    maxPreload = 40
+    localStorage.setItem('library-max-preload', '40')
+  },
+  disable () {
+    maxPreload = 0
+    localStorage.setItem('library-max-preload', '0')
+    // Remove added tasks
+    removeOldIfNeeded()
+    taskQueue.splice(0)
+    preloadTasks.clear()
+  },
+  // Main module sends data to render process from this map
+  preloadTasks,
+  taskQueue,
+  failures
+}

--- a/dist/spa/webtorrent.html
+++ b/dist/spa/webtorrent.html
@@ -28,6 +28,7 @@
     should always in console of the renderer process.
   </div>
   <!-- <script src="wt-extention.js"></script> -->
+  <script src="torrent-file.js"></script>
   <script src="webtorrent.js" type="module"></script>
 </body>
 

--- a/dist/spa/webtorrent.js
+++ b/dist/spa/webtorrent.js
@@ -1,1 +1,1347 @@
-const WebTorrent=require("webtorrent"),wtVersion=require("webtorrent/package.json").version,{ipcRenderer:ipcRenderer}=require("electron"),crypto=require("crypto"),fs=require("fs"),path=require("path"),{setSecure:setSecure}=require("webtorrent/lib/peer"),FSChunkStore=require("fs-chunk-store"),is=require("electron-is"),{utimes:utimes}=require("utimes");import{useAlphabizProtocol,useClientEvents}from"./wt-extention.js";import preloader from"./webtorrent-preload.js";import utils from"./webtorrent-utils.js";import natTraversal from"./nat.js";const natPorts=[],isMac=is.macOS(),{setAttributeSync:setAttributeSync,removeAttributeSync:removeAttributeSync,listAttributesSync:listAttributesSync}=isMac?require("fs-xattr"):{setAttributeSync(){},removeAttributeSync(){},listAttributesSync(){}},setUtimes=e=>{if(isMac)if(fs.existsSync(e.path)){const t=Date.now(),r=()=>{setTimeout((()=>{utimes(e.path,{btime:t});const r=listAttributesSync(e.path);r&&r.includes("com.apple.progress.fractionCompleted")&&(console.log(`[Done] Set file progress to 1. ${e.path}`),removeAttributeSync(e.path,"com.apple.progress.fractionCompleted"))}),200)};if(1===e.progress)return r(),console.log(`${e.path} is finished. Skip adding progress.`);e.on("done",r),utimes(e.path,{btime:4437792e5}),setAttributeSync(e.path,"com.apple.progress.fractionCompleted","0.01")}else setTimeout((()=>setUtimes(e)),100)};class TrackerMap extends Map{set(e,t){if("object"!==typeof t)return console.error("Not an object",t);super.set(e,Object.assign({url:e},t,{timestamp:Date.now()}))}}let info=()=>{},verbose=()=>{};Object.defineProperty(global,"log",{set(e){info=e?console.log:()=>{},console.log("Toggle log",e)}}),Object.defineProperty(global,"verb",{set(e){verbose=e?console.log:()=>{},console.log("Toggle verb",e)}});const warn=console.error;let startServerInfoHash;process.env.NODE_ENV;const infoHashes=[],shouldDelete=[],speeder=new Map;let prevTime=Date.now(),deltaTime=1e3;const torrentToJson=e=>utils.torrentToJson(e,deltaTime,speeder),speedLimit=e=>"number"!==typeof e?-1:e>0?parseInt(e):-1,getPublicPath=e=>{if(!e||0===e.length)return"";let t=path.dirname(e[0]);for(let r=1;r<e.length;r++)while(!e[r].includes(t)&&t.length>1)t=path.dirname(t);return t},locked=new Set;window.WEBTORRENT_ANNOUCEMENT=require("create-torrent").announceList.map((e=>e[0]));const VERSION_STR=wtVersion.replace(/\d*./g,(e=>("0"+e%100).slice(-2))).slice(0,4),peerId=Buffer.from(`-WW${VERSION_STR}-${crypto.randomBytes(9).toString("base64")}`);let client=null;const initClient=(e=0)=>{if(e>10)return;if(client&&client.torrents.length)return info("Client is not idle, keep it alive");const t={peerId:peerId,maxConns:20},r=parseInt(localStorage.getItem("dhtPort")),o=parseInt(localStorage.getItem("torrentPort"));isNaN(r)||(t.dhtPort=r),isNaN(o)||(t.torrentPort=o);const n=parseInt(localStorage.getItem("maximumConnectionsNum"));isNaN(n)||(t.maxConns=n);const s=parseInt(localStorage.getItem("downloadSpeed")),i=parseInt(localStorage.getItem("uploadSpeed")),a=Number(localStorage.getItem("payedUserShareRate"));t.blocklist=utils.getLocalIPList()||[];const l=localStorage.getItem("webtorrent-secure")||"auto";["auto","enable","disable"].includes(l)?setSecure(l):(setSecure("auto"),localStorage.setItem("webtorrent-secure","auto")),info("init client",t),client=new WebTorrent(t),client.natTraversal=natTraversal,isNaN(s)||client.throttleDownload(s),isNaN(i)||isNaN(a)||client.throttleUpload(i,a),client.on("error",(t=>{warn(t),r&&o&&(e+=1,info("try use difference port"),localStorage.setItem("dhtPort",r+e),localStorage.setItem("torrentPort",o+e),initClient(e)),ipcRenderer.send("webtorrent-client-error",t.message)})),client.on("warning",(e=>{warn(e),ipcRenderer.send("webtorrent-client-warn",e.message)})),client.on("ready",(()=>{console.log("initted"),ipcRenderer.send("webtorrent-initted")})),client.dht.on("listening",(()=>{const e=client.dht.address();console.log("DHT listening",e),natTraversal.portMapping&&(natTraversal.portMapping(e.port,"udp"),natPorts.push(e.port))})),client.on("listening",(()=>{if(console.log("Client listening",client._connPool),client._connPool&&client._connPool.tcpServer){const e=client._connPool.tcpServer.address();console.log("TCP Server",e),natTraversal.portMapping(e.port,"tcp"),natPorts.push(e.port)}})),window.client=client,useClientEvents(client)};setInterval((()=>{client&&client.torrents.forEach((e=>{e.paused||e.discovery&&e.discovery.tracker&&e.discovery.tracker.update()}))}),1e4);const addTracker=(e,t)=>{const r=t&&t.trim(),o="string"===typeof e?client.get(e):e;o&&o.trackerMap&&(o.trackerMap.has(r)||(console.log("add tracker",e,r,o.trackerMap.get(r),o.trackerMap.size),o.trackerMap.set(r,{status:"connecting"}),utils.addTracker(o,r)))},removeTracker=(e,t)=>{const r="string"===typeof e?client.get(e):e;r&&r.trackerMap&&utils.removeTracker(r,t,(()=>{r.trackerMap.delete(t)}))};global.addTracker=addTracker,global.removeTracker=removeTracker;let sendPreloadTasks="1"===localStorage.getItem("send-preload-tasks");const queueTimeout=(e,t)=>{const r=Date.now(),o=()=>{Date.now()-r>=t?e():requestAnimationFrame(o)};requestAnimationFrame(o)};let shouldSendInfo=!0;const updateTorrent=(e=!1)=>{if(!shouldSendInfo&&!e)return queueTimeout(updateTorrent,1e3),info("skip send");verbose("update torrent");const t=Date.now();deltaTime=(t-prevTime)/1e3,prevTime=t;let r=0,o=0;if(client.torrents.length){const e=client.torrents.filter((e=>!shouldDelete.includes(e.infoHash)&&!(e.isAutoUpload&&!e.ready&&!e.verifyStatus))),t=e.map((e=>{e.done||"number"!==typeof e.usedTime||(e.usedTime+=1e3);const t=torrentToJson(e);if(speeder.has(t.infoHash)&&e.ready){const n=speeder.get(t.infoHash);0===n.downloaded?t.downloadSpeed=0:t.downloadSpeed=Math.floor((e.downloaded-n.downloaded)/deltaTime),0===n.uploaded?t.uploadSpeed=0:t.uploadSpeed=Math.floor((e.uploaded-n.uploaded)/deltaTime),t.downloadSpeed<0&&(t.downloadSpeed=0),t.uploadSpeed<0&&(t.uploadSpeed=0),r+=t.downloadSpeed,o+=t.uploadSpeed,speeder.set(t.infoHash,{downloaded:e.downloaded,uploaded:e.uploaded})}else t.downloadSpeed=0,t.uploadSpeed=0,speeder.set(t.infoHash,{downloaded:0,uploaded:0});return t}));isMac&&t.forEach((e=>{if(e.upload||1===e.progress||e.isSeeding)return;const t=e.files;t.forEach((e=>{if("path"in e&&"progress"in e&&fs.existsSync(e.path)){if(e.progress<.01)return;setAttributeSync(e.path,"com.apple.progress.fractionCompleted",e.progress.toFixed(2))}}))})),info("send torrents",t),ipcRenderer.send("webtorrent-torrents",t)}else client.ready&&ipcRenderer.send("webtorrent-torrents",[]);if(ipcRenderer.send("webtorrent-client-info",{downloadSpeed:r<0?0:r,uploadSpeed:o<0?0:o,progress:client.progress,taskNum:client.torrents.length}),client.torrents.length>50&&(client.maxConns=Math.min(client.maxConns,10)),!e){if(sendPreloadTasks){const e=[];for(const[t,r]of preloader.preloadTasks.entries()){const{torrentPath:o,downloadPath:n,torrent:s}=r;s&&e.push({abUrl:t,torrentPath:o,downloadPath:n,torrent:s,postTitle:s.postTitle||""})}for(const t of preloader.taskQueue)e.find((e=>e.abUrl===t.url))||e.push({abUrl:t.origin,torrentPath:null,downloadPath:null,torrent:null,postTitle:t.postTitle});for(const t of preloader.failures)e.find((e=>e.abUrl===t.url))||e.push({abUrl:t.origin,torrentPath:null,downloadPath:null,torrent:null,postTitle:t.postTitle,failed:!0});ipcRenderer.send("webtorrent-preload",e)}else ipcRenderer.send("webtorrent-preload",[]);client.torrents.length>100?(client.maxConns=Math.min(client.maxConns,5),queueTimeout(updateTorrent,2e3)):queueTimeout(updateTorrent,1e3)}};queueTimeout(updateTorrent,1e3);let queueUpdate=null;const forceUpdateTorrent=()=>{queueUpdate&&(clearTimeout(queueUpdate),queueUpdate=setTimeout((()=>{queueUpdate=null,updateTorrent(!0)}),100))},onDone=e=>{if(setTimeout((()=>{isMac&&e.files&&e.files.length&&e.files.forEach((e=>{const t=listAttributesSync(e.path);t&&t.includes("com.apple.progress.fractionCompleted")&&(console.log(`[Done] Set file progress to 1. ${e.path}`),removeAttributeSync(e.path,"com.apple.progress.fractionCompleted","1"))}))}),1e3),e.upload)return console.log("skip upload");e.isSeeding=!0;const t=torrentToJson(e);e.completedTime||(e.completedTime=Date.now()),ipcRenderer.send("webtorrent-done",t),ipcRenderer.send("webtorrent-finish-all-payments",t)},onReady=e=>{e.files.forEach((e=>{e.name.match(/^_____padding_file_(.*)____$/)&&info("deselect",e.name),isMac&&e.path&&setUtimes(e)}));const t=torrentToJson(e);info("ready",t),ipcRenderer.send("webtorrent-ready",t),startServerInfoHash===t.infoHash&&(startServer(t.infoHash,t),startServerInfoHash=""),0===client.torrents.filter((e=>!e.ready)).length&&info("All torrents are ready")},onMetadata=(e,t)=>{ipcRenderer.send("webtorrent-metadata",e.infoHash),ipcRenderer.send("webtorrent-data",torrentToJson(e))},onWire=(e,t,r)=>{if(e.use(r),"webrtc"===e.type){const r=()=>{if(e.remoteAddress)return;const o=t._peers[e.peerId];if(!o)return setTimeout(r,1e3);const n=o.conn?._pc?.currentRemoteDescription?.sdp?.match(/c=IN\sIP\d\s(.*)/)?.[1];if(!n)return setTimeout(r,1e3);e.remoteAddress=n};r()}},onInfoHash=(e,t,r,o)=>{info("infoHash",e);while(shouldDelete.includes(e))shouldDelete.splice(shouldDelete.indexOf(e),1);infoHashes.includes(e)&&client.get(e)!==t?(info("Destroy tr"),ipcRenderer.send("webtorrent-existed",e),t.destroy()):ipcRenderer.send("webtorrent-infohash",e,{...r,isSeeding:o}),infoHashes.push(e),forceUpdateTorrent()},addListeners=(e,t={},r=!1)=>{t||(t={}),e.pending=!1,e.removeAllListeners(),e.setMaxListeners(0),info(`Add listeners to torrent ${e.infoHash||e.token||e.origin}`),e.on("done",(()=>onDone(e))),e.on("ready",(()=>onReady(e))),e.on("metadata",(()=>onMetadata(e,t))),e.on("infoHash",(o=>{onInfoHash(o,e,t,r)})),e.on("warning",(()=>{})),e.on("error",(r=>{console.log("Torrent error",r,t),ipcRenderer.send("webtorrent-error",torrentToJson(e),r.message)}));const o=useAlphabizProtocol(client,e);e.on("wire",(t=>onWire(t,e,o))),e.on("discovery",(()=>{if(e.discovery){if(info("start discovery"),e.trackerMap=new TrackerMap,e.discovery._announce.forEach((t=>{if(verbose("Discovered",t),e.trackerMap.set(t,{status:"connecting"}),!t.startsWith("ws")){if(t.match(/(\d{1,3}\.){3}\d{1,3}/))return;e.trackerMap.set(t+"@6",{status:"connecting"})}})),e.discovery.tracker.on("warning",((t,r,o)=>{if(verbose("tracker warning",r,t.message,o),!r)return console.warn("No emitted url",t);6===o&&(r+="@6"),e.trackerMap.set(r,{status:"error",message:utils.parseTrackerWarning(t.message)})})),e.discovery.tracker.on("update",((t,r,o)=>{if(verbose("tracker update",r,t),!r)return console.warn("No emitted url",t);6===o&&(r+="@6"),e.trackerMap.set(r,{status:"updated",info:t})})),t.customTrackers)for(const r of t.customTrackers)addTracker(e,r)}else info("no discovery")}))},addTorrent=(e,t,r)=>{if(verbose("Add torrent",e,t),t.isSeeding&&1===t.progress)return seedTorrent(e,t.file,t);if(t.infoHash){const e=t.infoHash.match(/btih:([^&]*)/),r=e&&e[1]||t.infoHash;if(r&&client.get(r))return info("exist",client.get(r)),ipcRenderer.send("webtorrent-existed",r)}if(t.origin){if(locked.has(t.origin))return info("origin lock",t.origin),locked.delete(t.origin);locked.add(t.origin)}if(t.token!==t.origin){if(locked.has(t.token))return info("token lock",t.token),info(locked),locked.delete(t.token);locked.add(t.token)}const o=()=>{const o=t.torrentPath&&fs.existsSync(t.torrentPath)?t.torrentPath:fs.existsSync(t.token||t.origin)?t.token||t.origin:t.infoHash;info(o);const n=client.add(o,{path:t.path||t.downloadDirectory,store:FSChunkStore,storeOpts:{postTitle:t.postTitle||""},storeCacheSlots:1,strategy:"sequential",maxWebConns:client.maxConns,announce:[...t.trackers||[],...WEBTORRENT_ANNOUCEMENT]});n.token=e,n.origin=t.infoHash||t.token||t.origin,n.createdTime=t.createdTime||Date.now(),n.usedTime=t.usedTime||0,t.fromPost&&(n.fromPost=t.fromPost),t.postTitle&&(n.postTitle=t.postTitle),t.name&&(n.name=t.name),t.subtitleList&&t.subtitleList.length&&(n.subtitleList=t.subtitleList),verbose("Torrent conf",n),addListeners(n,t),verbose("Listener added"),n.once("infoHash",(()=>{locked.delete(t.origin),locked.delete(n.infoHash),locked.delete(t.token),r&&r(n)})),t.verifiedPieces&&n.once("metadata",(()=>{if(n.length<2e8)return;let e=0,r=.2;n.length>5e9&&(r=.1),n.length>2e10&&(r=.05),n.length>5e10&&(r=.01),n.length>1e11&&(r=.005),t.verifiedPieces.forEach((t=>{if(Array.isArray(t)){const[r,o]=t;for(let t=r+1;t<o-1;t++)n._markVerified(t),e++}else isNaN(t)||(n._markVerified(t),e++)})),info("mark verified",t.verifiedPieces,e)}))};if(client.get(t.infoHash))client.remove(t.infoHash,o);else if(client.torrents.some((t=>t.token===e))){const t=client.torrents.find((t=>t.token===e));if(!t)return o();if(t.infoHash)return r&&r(t);t.once("infoHash",(()=>r&&r(t)))}else o()},stopTorrent=e=>{if(locked.has(e))return;locked.add(e),server&&serverInfoHash===e&&(server.destroy(),server=null,serverInfoHash="");const t=client.get(e);if(t&&(t.isSeeding||t.done)&&(t.completed=!0),t)ipcRenderer.send("webtorrent-finish-all-payments",torrentToJson(t)),t.destroy((()=>{locked.delete(e),ipcRenderer.send("webtorrent-stop",e,t.completed)}));else if(locked.delete(e),e){const t=client.torrents.find((t=>t.token===e));t&&t.destroy((()=>{locked.delete(e),ipcRenderer.send("webtorrent-stop",e,t.completed)}))}else ipcRenderer.send("webtorrent-notfound",e);infoHashes.includes(e)&&infoHashes.splice(infoHashes.indexOf(e),1),forceUpdateTorrent()},deleteTorrent=(e,t,r)=>{if(locked.has(e))return;locked.add(e),shouldDelete.push(e),server&&serverInfoHash===e&&(server.destroy(),server=null,serverInfoHash="");const o=client.get(e)||client.torrents.find((t=>t.token===e));if(info("delete",e,o,t),o){o.emit("deleted"),info("emit",o.emit);const n=o.files.length?o.files.map((e=>e.path)):o.file||[],s=getPublicPath(n);o.destroy({destroyStore:t},(()=>{"function"===typeof r&&r(),t?ipcRenderer.send("webtorrent-delete",o.infoHash||e,s,n):ipcRenderer.send("webtorrent-delete",o.infoHash||e),locked.delete(e);try{client.remove(o.infoHash)}catch(i){}}))}else locked.delete(e),ipcRenderer.send("webtorrent-notfound",e);while(infoHashes.includes(e))infoHashes.splice(infoHashes.indexOf(e),1);forceUpdateTorrent()},seedTorrent=(e,t,r,o=!1,n=null)=>{if(r.infoHash&&client.get(r.infoHash))return info("skip existed",r.infoHash);const s=r.infoHash||r.token||r.origin||(Array.isArray(t)?t[0]:t);if(s){if(locked.has(s))return;locked.add(s)}let i=null;const a=[...r.trackers||[],...WEBTORRENT_ANNOUCEMENT],l={...r,store:FSChunkStore,storeOpts:{postTitle:r.postTitle||""},storeCacheSlots:1,strategy:"sequential",maxWebConns:client.maxConns,announce:a};if(r.infoHash&&!r.upload&&r.files.length)info("[seed] add torrent with token"),info(r),i=client.add(r.infoHash||r.token||r.origin,Object.assign(l,{path:r.path||r.downloadDirectory,skipVerify:1===r.progress}));else if(r.isSeeding&&r.torrentPath&&fs.existsSync(r.torrentPath))info("[seed] add torrent with torrentPath"),i=client.add(r.torrentPath,Object.assign(l,{path:r.path||r.downloadDirectory,skipVerify:!0}));else if(r.isSeeding&&r.magnetURI&&!r.isUploadByFiles)info("[seed] add torrent with magnetURI"),i=client.add(r.magnetURI,Object.assign(l,{path:r.path||r.downloadDirectory,skipVerify:!0})),i.upload=!0,i.isSeeding=!0;else{info("[seed] Seed torrent with files",!!r.infoHash,r);const e=client.torrents.filter((e=>1===e.progress)),o=e.reduce(((e,t)=>{const r=t.files.map((e=>e.path));return e.push(...r),e}),[]);t.some((e=>o.includes(e)))&&ipcRenderer.send("webtorrent-seed-error","task_exists"),i=client.seed(t,Object.assign(l,{skipVerify:!!r.infoHash,onProgress(e,t){i.verifyStatus={current:e,total:t}}})),i.isUploadByFiles=!0}return info("seedTorrent",r,i,t),r.name&&(i.name=r.name),i.isAutoUpload=o,i.token=e,i.isSeeding=!0,i.upload=!0,i.paused=!1,i.file=t,i.createdTime=r.createdTime||Date.now(),addListeners(i,r,!0),i.once("infoHash",(()=>{locked.delete(s),n&&n()})),i.once("metadata",(()=>{ipcRenderer.send("webtorrent-seed",torrentToJson(i))})),i.once("deleted",(()=>{l.onProgress&&(l.onProgress._destroyed=!0)})),i},getTorrent=()=>{const e=client.torrents.map((e=>torrentToJson(e)));return info(e),ipcRenderer.send("webtorrent-list",e)},setThrottleGroup=({infoHash:e,peerId:t,subId:r,level:o})=>{const n=client.get(e);if(!n)return info("not found",e),ipcRenderer.send("webtorrent-set-throttle",{code:-1,message:"Torrent Not Found"}),null;let s=null,i=null;for(const l of n.wires)if(r?l.remoteSub===r:l.peerId===t){s=l;try{l._setThrottleGroup(o)}catch(a){i={code:-1,message:a.message}}break}return s?i?ipcRenderer.send("webtorrent-set-throttle",i):ipcRenderer.send("webtorrent-set-throttle",{code:0,message:"success"}):ipcRenderer.send("webtorrent-set-throttle",{code:-1,message:"Peer Not Found"}),s},saveTorrentFile=(e,t)=>{const r="webtorrent-save-torrent",o=client.get(e);if(!o)return;if(!o.torrentFile||!o.name)return ipcRenderer.send(r,{code:-1,message:"Torrent Not Ready"});const n=path.resolve(t,`${o.name}.torrent`);if(fs.existsSync(n))return ipcRenderer.send(r,{code:0,message:"success",infoHash:e,torrentPath:n});fs.existsSync(t)||fs.mkdirSync(t,{recursive:!0}),fs.writeFileSync(n,o.torrentFile),ipcRenderer.send(r,{code:0,message:"success",infoHash:e,torrentPath:n})};let server=null,serverInfoHash="";const startTorrentServer=e=>{if(info("Start server",e),startServerInfoHash="",server){if(serverInfoHash===e.infoHash)return ipcRenderer.send("webtorrent-server-ready",e.infoHash,{token:e.token,port:server.address().port});server.destroy(),server=null,serverInfoHash=""}info("Create server",e),server=e.createServer(),server.listen(0,(()=>{const t=server.address().port,r={token:e.token,port:t};ipcRenderer.send("webtorrent-server-ready",e.infoHash,r);const o=()=>{const t=e.files.map((t=>{const r=[];for(let o=t._startPiece;o<t._endPiece;o++)r.push(null===e.pieces[o]?1:0);return{name:t.name,path:t.path,progress:r}}));ipcRenderer.send("webtorrent-server-progress",e.infoHash,t)};setTimeout(o,1e3);const n=setInterval(o,5e3);server.once("close",(()=>clearInterval(n)))}))},startServer=(e,t)=>{info("start server",e,t),startServerInfoHash=e;const r=client.get(e);if(!r)return addTorrent(t.token||t.infoHash,t,(()=>startServer(e,t)));r.ready?(info("tr ready. start server"),startTorrentServer(r,t)):r.once("ready",(()=>startTorrentServer(r,t)))},stopServer=()=>{server&&(server.destroy(),server=null,serverInfoHash="",info("Destroy server"))};(function(){ipcRenderer.once("redirect-log",((e,t)=>{console.log("Write webtorrent logs to",t),utils.useRedirectLogs(t)})),ipcRenderer.on("add-torrent",((e,t,r)=>{if(r.magnetURI&&!r.torrentPath){const e=preloader.loadCache(r.magnetURI,r.path);e?(console.log("[Preload] Load cached task",e),r.torrentPath=e):console.log("Cannot find preloaded task for",r)}return addTorrent(t,r)})),ipcRenderer.on("stop-torrent",((e,t)=>(console.log("got stop",t),stopTorrent(t)))),ipcRenderer.on("stop-all-uploading",((e,t)=>{t.forEach((e=>{const t=client.torrents.find((t=>!(!t.infoHash||t.infoHash!==e.infoHash)||!(!t.token||t.token!==e.token)));t&&t.destroy()}))})),ipcRenderer.on("delete-all",((e,t,r,o)=>{shouldSendInfo=!1,info("Delete all",t,r,o);const n=client.torrents.filter((e=>{if("all"===t)return!0;const r=e.upload||1===e.progress||e.isSeeding;return"upload"===t?!(!o&&e.isAutoUpload)&&r:!r}));if(!n.length)return void(shouldSendInfo=!0);let s=0;n.forEach((t=>{s++,info(t.infoHash),shouldDelete.push(t.infoHash),t.removeAllListeners();try{deleteTorrent(t.infoHash,r,(()=>{shouldDelete.includes(t.infoHash)&&shouldDelete.splice(shouldDelete.indexOf(t.infoHash),1),s--,0===s&&(shouldSendInfo=!0)}))}catch(e){}})),setTimeout((()=>{shouldSendInfo=!0}),2e3)})),ipcRenderer.on("seed-torrent",((e,t)=>{let{file:r,token:o,...n}=t;return r||(r=t.files.map((e=>e.path))),console.log(t),r.length?(o||(o=Math.random().toString().substr(2)),seedTorrent(o,r,n)):ipcRenderer.send("seed-error")})),ipcRenderer.on("seed-torrents",((e,t)=>{info(`Seed ${t.length} torrents`),t.forEach((e=>{let{file:t,token:r,...o}=e;t||(t=e.files.map((e=>e.path))),r||(r=Math.random().toString().substring(2)),seedTorrent(r,t,{...e})}))})),ipcRenderer.on("autoupload-files",(async(e,t)=>{info("autoupload files",t),Promise.all(t.map((e=>{if(info("Auto upload",e),!client.torrents.some((t=>t.files.some((t=>t.path===e))||t.file&&t.file.some&&t.file.some((t=>t===e))||t.file===e)))return new Promise((t=>{seedTorrent("autoupload-"+path.basename(e),[e],{path:path.dirname(e)},!0,t)}));info(`${e} is already uploaded, skipped`)}))).then((()=>{info("autoupload complete"),ipcRenderer.send("autoupload-complete")})).catch((e=>{ipcRenderer.send("autoupload-complete",e.message||e)}));const r=[];client.torrents.forEach((e=>{e.isAutoUpload&&e.ready&&(e.files.some((e=>t.includes(e.path)))?info(`${e.infoHash} is kept alive`):(info(`${e.infoHash} has been deleted. Destroy`,e.files.map((e=>e.path))),r.push(e)))})),r.forEach((e=>{e.destroy((()=>{ipcRenderer.send("webtorrent-delete",e.infoHash)}))}))})),ipcRenderer.on("start-server",((e,{infoHash:t,conf:r})=>(info("start server",t,r),startServer(t,r)))),ipcRenderer.on("stop-server",(()=>stopServer())),ipcRenderer.on("delete-torrent",((e,t,r)=>deleteTorrent(t,r))),ipcRenderer.on("pend-torrent",((e,t)=>{const r=client.get(t.infoHash);infoHashes.includes(t.infoHash)&&infoHashes.splice(infoHashes.indexOf(t.infoHash),1),info("Pend",t.infoHash,r),r&&(r.removeAllListeners(),r.destroy(),r.pending=!0,ipcRenderer.send("webtorrent-pending",torrentToJson(r)))})),ipcRenderer.on("set-throttle-group",((e,{infoHash:t,peerId:r,subId:o,level:n})=>{info(t,r,o,n),setThrottleGroup({infoHash:t,peerId:r,subId:o,level:n})})),ipcRenderer.on("save-torrent-file",((e,t,r)=>saveTorrentFile(t,r))),ipcRenderer.on("update-settings",((e,{uploadSpeed:t,downloadSpeed:r,maximumConnectionsNum:o,DHTlistenPort:n,BTlistenPort:s,payedUserShareRate:i,secureOption:a,libraryPreload:l,showPreload:d})=>{const c=parseInt(n),p=parseInt(s);if(info("Set client",{uploadSpeed:t,downloadSpeed:r,maximumConnectionsNum:o,dhtPort:c,torrentPort:p,payedUserShareRate:i,secureOption:a,libraryPreload:l,showPreload:d}),i){const e=Number(i)||.7;localStorage.setItem("payedUserShareRate",e.toString())}if(t){const e=speedLimit(t);localStorage.setItem("uploadSpeed",e.toString())}const f=Number(localStorage.getItem("payedUserShareRate"))||.7,u=parseInt(localStorage.getItem("uploadSpeed"));if(isNaN(f)||isNaN(u)||(-1===u?client.throttleUpload(-1):client.throttleUpload(u,f)),r){const e=speedLimit(r);client.throttleDownload(e),localStorage.setItem("downloadSpeed",e.toString())}o&&(client.maxConns=o,localStorage.setItem("maximumConnectionsNum",o.toString()));let h=!1;c&&c!==parseInt(localStorage.getItem("dhtPort"))&&(h=!0,localStorage.setItem("dhtPort",c.toString())),p&&p!==parseInt(localStorage.getItem("torrentPort"))&&(h=!0,localStorage.setItem("torrentPort",p.toString())),"string"===typeof a&&(localStorage.setItem("webtorrent-secure",a),setSecure(a),info("set secure",a)),h&&location.reload(),!0===l?preloader.enable():!1===l&&preloader.disable(),!0===d?(sendPreloadTasks=!0,localStorage.setItem("send-preload-tasks","1")):!1===d&&(sendPreloadTasks=!1,localStorage.setItem("send-preload-tasks","0"))})),ipcRenderer.on("reset-torrent",(()=>{info("reset"),shouldSendInfo=!1,Promise.all(client.torrents.map((e=>new Promise((t=>{e.removeAllListeners(),e.destroy({destroyStore:!0},t)}))))).then((()=>ipcRenderer.send("webtorrent-reset"))).catch((()=>ipcRenderer.send("webtorrent-reset-error"))).finally((()=>{info("resetted"),client.torrents.length=0,shouldSendInfo=!0}))})),ipcRenderer.on("add-tracker",((e,{infoHash:t,url:r})=>{info("add-tracker",t,r),addTracker(t,r)})),ipcRenderer.on("remove-tracker",((e,{infoHash:t,url:r})=>{info("remove-tracker",t,r),removeTracker(t,r)})),ipcRenderer.on("force-exit",(()=>process.exit(0))),setInterval((()=>{process.memoryUsage().rss/1e9>3.5&&(info("exit for memory reason"),process.exit(0))}),6e4),initClient(0),window.addEventListener("error",(e=>(info(e.message||e),!0))),ipcRenderer.on("before-quit",(()=>{natPorts.forEach((e=>{natTraversal.portUnMapping(e)}))})),"undefined"!==typeof window&&window.addEventListener("beforeunload",(()=>{natPorts.forEach((e=>{natTraversal.portUnMapping(e)}))}))})();
+const WebTorrent = require('webtorrent')
+const wtVersion = require('webtorrent/package.json').version
+const { ipcRenderer } = require('electron')
+const crypto = require('crypto')
+const fs = require('fs')
+const path = require('path')
+const { saveTorrentByName } = globalThis.alphabizTorrentFile || {}
+if (typeof saveTorrentByName !== 'function') {
+  throw new Error('Torrent file security boundary is not loaded')
+}
+const { setSecure } = require('webtorrent/lib/peer')
+// const diskusage = require('diskusage')
+const FSChunkStore = require('fs-chunk-store')
+const is = require('electron-is')
+const { utimes } = require('utimes')
+
+import { useAlphabizProtocol, useClientEvents } from './wt-extention.js'
+import preloader from './webtorrent-preload.js'
+import utils from './webtorrent-utils.js'
+import natTraversal from './nat.js'
+const natPorts = []
+
+const isMac = is.macOS()
+const { setAttributeSync, removeAttributeSync, listAttributesSync } = isMac ? require('fs-xattr') : {
+  setAttributeSync () {},
+  removeAttributeSync () {},
+  listAttributesSync () {}
+}
+
+const setUtimes = (file) => {
+  if (!isMac) return
+  if (fs.existsSync(file.path)) {
+    const createdTime = Date.now()
+    const onDone = () => {
+      setTimeout(() => {
+        utimes(file.path, {
+          btime: createdTime
+        })
+        const attrs = listAttributesSync(file.path)
+        if (attrs && attrs.includes('com.apple.progress.fractionCompleted')) {
+          console.log(`[Done] Set file progress to 1. ${file.path}`)
+          // Reset created time
+          removeAttributeSync(file.path, 'com.apple.progress.fractionCompleted')
+        }
+      }, 200)
+    }
+    if (file.progress === 1) {
+      onDone()
+      return console.log(`${file.path} is finished. Skip adding progress.`)
+    }
+    file.on('done', onDone)
+    /**
+     * DO NOT TOUCH!
+     * The number is a magic code used by macOS. If the create time of file
+     * is not set to this value, the download progress pie will not shown
+     * in finder. This is the timestamp of `1984-01-24 08:00:00 +0000`.
+     */
+    utimes(file.path, {
+      btime: 443779200000
+    })
+    setAttributeSync(file.path, 'com.apple.progress.fractionCompleted', '0.01')
+  } else {
+    setTimeout(() => setUtimes(file), 100)
+  }
+}
+
+/**
+ * @typedef { import('../src/types').TrackerStatus } TrackerStatus
+ */
+/**
+ * @class TrackerMap
+ * @extends { Map<string, TrackerStatus> }
+ */
+class TrackerMap extends Map {
+  /**
+   * @method set
+   * @param { string } key
+   * @param { TrackerStatus } value
+   */
+  set (key, value) {
+    if (typeof value !== 'object') return console.error('Not an object', value)
+    super.set(key, Object.assign(
+      { url: key },
+      value,
+      { timestamp: Date.now() }
+    ))
+  }
+}
+
+let info = () => {} // console.log
+let verbose = () => {} // console.log
+// Use this to keep logger with correct caller line
+Object.defineProperty(global, 'log', {
+  set (v) {
+    if (v) info = console.log
+    else info = () => {}
+    console.log('Toggle log', v)
+  }
+})
+Object.defineProperty(global, 'verb', {
+  set (v) {
+    if (v) verbose = console.log
+    else verbose = () => {}
+    console.log('Toggle verb', v)
+  }
+})
+const warn = console.error
+if (process.env.NODE_ENV === 'development') {
+  // global.log = true
+  // global.verb = true
+}
+let startServerInfoHash
+const infoHashes = []
+const shouldDelete = []
+/**
+ * @typedef { import('../src/types').TorrentInfo } TorrentInfo
+ * @typedef { import('webtorrent/lib/torrent') } RawTorrent
+ * @typedef { RawTorrent & TorrentInfo } Torrent
+ */
+// The lib `speedometer` webtorrent dependents performed bad.
+// Use customized speeder instead.
+const speeder = new Map()
+let prevTime = Date.now()
+let deltaTime = 1000
+/**
+ * @method torrentToJson
+ * @param { Torrent } tr
+ * @param { boolean } isUpload
+ * @returns { Partial<Torrent> }
+ */
+const torrentToJson = (tr) => {
+  return utils.torrentToJson(tr, deltaTime, speeder)
+}
+/** @param { number } speed */
+const speedLimit = speed => {
+  if (typeof speed !== 'number') return -1
+  return speed > 0 ? parseInt(speed) : -1
+}
+/** @param { string[] } paths */
+const getPublicPath = (paths) => {
+  if (!paths || paths.length === 0) return ''
+  let dir = path.dirname(paths[0])
+  for (let i = 1; i < paths.length; i++) {
+    while (!paths[i].includes(dir) && dir.length > 1) {
+      dir = path.dirname(dir)
+    }
+  }
+  return dir
+}
+
+const locked = new Set()
+
+/**
+ * @typedef { import('src/types').TorrentInfo } TorrentInfo
+ * @typedef { import('webtorrent/lib/torrent') } RawTorrent
+ * @typedef { RawTorrent & TorrentInfo } Torrent
+ */
+
+window.WEBTORRENT_ANNOUCEMENT = require('create-torrent').announceList
+  .map(arr => arr[0])
+
+const VERSION_STR = wtVersion
+  .replace(/\d*./g, v => `0${v % 100}`.slice(-2))
+  .slice(0, 4)
+const peerId = Buffer.from(`-WW${VERSION_STR}-${crypto.randomBytes(9).toString('base64')}`)
+
+/** @type { WebTorrent.Instance } */
+let client = null
+const initClient = (retries = 0) => {
+  if (retries > 10) return
+  if (client) {
+    if (client.torrents.length) return info('Client is not idle, keep it alive')
+  }
+
+  const conf = {
+    peerId,
+    maxConns: 20
+  }
+  const dhtPort = parseInt(localStorage.getItem('dhtPort'))
+  const torrentPort = parseInt(localStorage.getItem('torrentPort'))
+  if (!isNaN(dhtPort)) conf.dhtPort = dhtPort
+  if (!isNaN(torrentPort)) conf.torrentPort = torrentPort
+  const maxConns = parseInt(localStorage.getItem('maximumConnectionsNum'))
+  if (!isNaN(maxConns)) conf.maxConns = maxConns
+  const downloadSpeed = parseInt(localStorage.getItem('downloadSpeed'))
+  const uploadSpeed = parseInt(localStorage.getItem('uploadSpeed'))
+  const payedUserShareRate = Number(localStorage.getItem('payedUserShareRate'))
+  // block local IP
+  conf.blocklist = utils.getLocalIPList() || []
+
+  // Secure setting
+  // conf.secure = true
+  const secureOption = localStorage.getItem('webtorrent-secure') || 'auto'
+  if (['auto', 'enable', 'disable'].includes(secureOption)) {
+    setSecure(secureOption)
+  } else {
+    setSecure('auto')
+    localStorage.setItem('webtorrent-secure', 'auto')
+  }
+
+  info('init client', conf)
+  client = new WebTorrent(conf)
+  client.natTraversal = natTraversal
+  if (!isNaN(downloadSpeed)) client.throttleDownload(downloadSpeed)
+  if (!isNaN(uploadSpeed) && !isNaN(payedUserShareRate)) client.throttleUpload(uploadSpeed, payedUserShareRate)
+  client.on('error', e => {
+    warn(e)
+    if (dhtPort && torrentPort) {
+      retries += 1
+      info('try use difference port')
+      localStorage.setItem('dhtPort', dhtPort + retries)
+      localStorage.setItem('torrentPort', torrentPort + retries)
+      initClient(retries)
+    }
+    ipcRenderer.send('webtorrent-client-error', e.message)
+  })
+  client.on('warning', e => {
+    warn(e)
+    ipcRenderer.send('webtorrent-client-warn', e.message)
+  })
+  client.on('ready', () => {
+    console.log('initted')
+    ipcRenderer.send('webtorrent-initted')
+  })
+  client.dht.on('listening', () => {
+    const address = client.dht.address()
+    console.log('DHT listening', address)
+    if (natTraversal.portMapping) {
+      natTraversal.portMapping(address.port, 'udp')
+      natPorts.push(address.port)
+    }
+  })
+  client.on('listening', () => {
+    console.log('Client listening', client._connPool)
+    if (client._connPool && client._connPool.tcpServer) {
+      const address = client._connPool.tcpServer.address()
+      console.log('TCP Server', address)
+      natTraversal.portMapping(address.port, 'tcp')
+      natPorts.push(address.port)
+    }
+  })
+  window.client = client
+  useClientEvents(client)
+}
+setInterval(() => {
+  if (!client) return
+  client.torrents.forEach(torrent => {
+    if (torrent.paused) return
+    if (!torrent.discovery || !torrent.discovery.tracker) return
+    torrent.discovery.tracker.update()
+  })
+}, 10_000)
+
+/**
+ * @param { string | Torrent } infoHash
+ * @param { string } url
+ */
+const addTracker = (infoHash, _url) => {
+  const url = _url && _url.trim()
+  /** @type { Torrent } */
+  const tr = typeof infoHash === 'string' ? client.get(infoHash) : infoHash
+  if (!tr || !tr.trackerMap) return
+  if (tr.trackerMap.has(url)) return
+  console.log('add tracker', infoHash, url, tr.trackerMap.get(url), tr.trackerMap.size)
+  tr.trackerMap.set(url, { status: 'connecting' })
+  utils.addTracker(tr, url)
+}
+/**
+ * @param { string | Torrent } infoHash
+ * @param { string } url
+ */
+const removeTracker = (infoHash, url) => {
+  /** @type { Torrent } */
+  const tr = typeof infoHash === 'string' ? client.get(infoHash) : infoHash
+  if (!tr || !tr.trackerMap) return
+  utils.removeTracker(tr, url, () => {
+    tr.trackerMap.delete(url)
+  })
+}
+global.addTracker = addTracker
+global.removeTracker = removeTracker
+
+let sendPreloadTasks = localStorage.getItem('send-preload-tasks') === '1' ? true : false
+/**
+ * `setTimeout` cannot be triggered if client is busy.
+ * Here we use rAF to ensure out callback runs as fast as posible
+ */
+const queueTimeout = (cb, timeout) => {
+  const start = Date.now()
+  const run = () => {
+    if (Date.now() - start >= timeout) cb()
+    else requestAnimationFrame(run)
+  }
+  requestAnimationFrame(run)
+}
+let shouldSendInfo = true
+const updateTorrent = (once = false) => {
+  // console.time('torrent status')
+  if (!shouldSendInfo && !once) {
+    queueTimeout(updateTorrent, 1000)
+    return info('skip send')
+  } else {
+    verbose('update torrent')
+  }
+  const curTime = Date.now()
+  deltaTime = (curTime - prevTime) / 1000
+  prevTime = curTime
+  let totalDownloadSpeed = 0
+  let totalUploadSpeed = 0
+  if (client.torrents.length) {
+    const allTorrents = client.torrents.filter(i => {
+      if (shouldDelete.includes(i.infoHash)) return false
+      if (i.isAutoUpload && !i.ready && !i.verifyStatus) return false
+      return true
+    })
+    const torrents = allTorrents.map(tr => {
+      if (!tr.done && typeof tr.usedTime === 'number') tr.usedTime += 1000
+      const t = torrentToJson(tr)
+      if (!speeder.has(t.infoHash) || !tr.ready) {
+        t.downloadSpeed = 0
+        t.uploadSpeed = 0
+        speeder.set(t.infoHash, {
+          downloaded: 0,
+          uploaded: 0
+        })
+      } else {
+        const prev = speeder.get(t.infoHash)
+        if (prev.downloaded === 0) t.downloadSpeed = 0
+        else t.downloadSpeed = Math.floor((tr.downloaded - prev.downloaded) / deltaTime)
+        if (prev.uploaded === 0) t.uploadSpeed = 0
+        else t.uploadSpeed = Math.floor((tr.uploaded - prev.uploaded) / deltaTime)
+        // if (!t.upload) info(prev.downloaded, tr.downloaded, t.downloadSpeed, deltaTime)
+        if (t.downloadSpeed < 0) t.downloadSpeed = 0
+        if (t.uploadSpeed < 0) t.uploadSpeed = 0
+        totalDownloadSpeed += t.downloadSpeed
+        totalUploadSpeed += t.uploadSpeed
+        speeder.set(t.infoHash, {
+          downloaded: tr.downloaded,
+          uploaded: tr.uploaded
+        })
+      }
+      return t
+    })
+    if (isMac) {
+      // TODO: update download progress for finder
+      torrents.forEach(tr => {
+        if (tr.upload || tr.progress === 1 || tr.isSeeding) return
+        // console.log('update progress for', tr)
+        const files = tr.files
+        files.forEach(f => {
+          if (('path' in f) && ('progress' in f) && fs.existsSync(f.path)) {
+            // The min value is '0.01'
+            if (f.progress < 0.01) return
+            // Set file progress
+            // console.log(`[Progress] Set file progress to ${f.progress}. ${f.path}`)
+            setAttributeSync(f.path, 'com.apple.progress.fractionCompleted', f.progress.toFixed(2))
+          }
+        })
+      })
+    }
+    info('send torrents', torrents)
+    // window._torrents = torrents
+    // torrents.forEach(tr => ipcRenderer.send('webtorrent-data', tr))
+    ipcRenderer.send('webtorrent-torrents', torrents)
+  } else if (client.ready) {
+    ipcRenderer.send('webtorrent-torrents', [])
+  }
+  ipcRenderer.send('webtorrent-client-info', {
+    downloadSpeed: totalDownloadSpeed < 0 ? 0 : totalDownloadSpeed,
+    uploadSpeed: totalUploadSpeed < 0 ? 0 : totalUploadSpeed,
+    progress: client.progress,
+    taskNum: client.torrents.length
+  })
+  // console.timeEnd('torrent status')
+  // if there are too many torrents in the client
+  // send info every seconds may cause performance issue
+  if (client.torrents.length > 50) {
+    client.maxConns = Math.min(client.maxConns, 10)
+  }
+  if (once) return
+  if (sendPreloadTasks) {
+    const preloadTasks = []
+    for (const [abUrl, values] of preloader.preloadTasks.entries()) {
+      const { torrentPath, downloadPath, torrent } = values
+      if (!torrent) continue
+      preloadTasks.push({ abUrl, torrentPath, downloadPath, torrent, postTitle: torrent.postTitle || '' })
+    }
+    for (const task of preloader.taskQueue) {
+      if (preloadTasks.find(t => t.abUrl === task.url)) continue
+      preloadTasks.push({
+        abUrl: task.origin,
+        torrentPath: null,
+        downloadPath: null,
+        torrent: null,
+        postTitle: task.postTitle
+      })
+    }
+    for (const task of preloader.failures) {
+      if (preloadTasks.find(t => t.abUrl === task.url)) continue
+      preloadTasks.push({
+        abUrl: task.origin,
+        torrentPath: null,
+        downloadPath: null,
+        torrent: null,
+        postTitle: task.postTitle,
+        failed: true
+      })
+    }
+    // console.log('send preload tasks', preloadTasks)
+    ipcRenderer.send('webtorrent-preload', preloadTasks)
+  } else {
+    ipcRenderer.send('webtorrent-preload', [])
+  }
+  if (client.torrents.length > 100) {
+    client.maxConns = Math.min(client.maxConns, 5)
+    queueTimeout(updateTorrent, 2000)
+  } else queueTimeout(updateTorrent, 1000)
+}
+queueTimeout(updateTorrent, 1000)
+
+let queueUpdate = null
+const forceUpdateTorrent = () => {
+  if (queueUpdate) {
+    clearTimeout(queueUpdate)
+    queueUpdate = setTimeout(() => {
+      queueUpdate = null
+      updateTorrent(true)
+    }, 100)
+  }
+}
+
+const onDone = (tr) => {
+  setTimeout(() => {
+    if (isMac && tr.files && tr.files.length) {
+      tr.files.forEach(file => {
+        const attrs = listAttributesSync(file.path)
+        if (attrs && attrs.includes('com.apple.progress.fractionCompleted')) {
+          console.log(`[Done] Set file progress to 1. ${file.path}`)
+          removeAttributeSync(file.path, 'com.apple.progress.fractionCompleted', '1')
+        }
+      })
+    }
+  }, 1000)
+  if (tr.upload) return console.log('skip upload')
+  tr.isSeeding = true
+  const json = torrentToJson(tr)
+  if (!tr.completedTime) tr.completedTime = Date.now()
+  ipcRenderer.send('webtorrent-done', json)
+  ipcRenderer.send('webtorrent-finish-all-payments', json)
+}
+/** @param { RawTorrent } tr */
+const onReady = (tr) => {
+  tr.files.forEach(/** @param { import('webtorrent/lib/file') } f */f => {
+    // BitComet 0.85+ uses these files itself but will never seed them,
+    // We just ignore them since we can do nothing to them.
+    if (f.name.match(/^_____padding_file_(.*)____$/)) {
+      info('deselect', f.name)
+    }
+    if (isMac && f.path) {
+      setUtimes(f)
+    }
+  })
+  const json = torrentToJson(tr)
+  info('ready', json)
+  ipcRenderer.send('webtorrent-ready', json)
+  if (startServerInfoHash === json.infoHash) {
+    startServer(json.infoHash, json)
+    startServerInfoHash = ''
+  }
+  // diskusage.check(tr.path, (err, result) => {
+  //   if (err) warn(err)
+  //   else {
+  //     const { free } = result
+  //     if (tr.length - tr.downloaded > free + 100_000_000) {
+  //       ipcRenderer.send('webtorrent-no-space', json)
+  //       stopTorrent(tr.infoHash)
+  //     }
+  //   }
+  // })
+  if (client.torrents.filter(i => !i.ready).length === 0) {
+    info('All torrents are ready')
+  }
+}
+const onMetadata = (tr, conf) => {
+  // info('metadata', torrentToJson({ ...conf, ...tr }))
+  ipcRenderer.send('webtorrent-metadata', tr.infoHash)
+  ipcRenderer.send('webtorrent-data', torrentToJson(tr))
+}
+const onWire = (wire, tr, abProtocol) => {
+  wire.use(abProtocol)
+  if (wire.type === 'webrtc') {
+    // info('onwire', wire.remoteAddress, wire.peerId)
+    const setAddress = () => {
+      if (wire.remoteAddress) return
+      const peer = tr._peers[wire.peerId]
+      if (!peer) return setTimeout(setAddress, 1000)
+      const address = peer.conn?._pc?.currentRemoteDescription?.sdp?.match(/c=IN\sIP\d\s(.*)/)?.[1]
+      if (!address) return setTimeout(setAddress, 1000)
+      wire.remoteAddress = address
+    }
+    setAddress()
+  }
+}
+const onInfoHash = (infoHash, tr, conf, isSeeding) => {
+  info('infoHash', infoHash)
+  while (shouldDelete.includes(infoHash)) {
+    shouldDelete.splice(shouldDelete.indexOf(infoHash), 1)
+  }
+  if (infoHashes.includes(infoHash)) {
+    if (client.get(infoHash) !== tr) {
+      info('Destroy tr')
+      ipcRenderer.send('webtorrent-existed', infoHash)
+      tr.destroy()
+    } else {
+      ipcRenderer.send('webtorrent-infohash', infoHash, { ...conf, isSeeding })
+    }
+  } else ipcRenderer.send('webtorrent-infohash', infoHash, { ...conf, isSeeding })
+  infoHashes.push(infoHash)
+  forceUpdateTorrent()
+}
+/**
+ * @function addListeners
+ * @param { Torrent } tr
+ * @param { TorrentInfo } conf
+ * @param { boolean } isSeeding
+ */
+const addListeners = (tr, conf = {}, isSeeding = false) => {
+  if (!conf) conf = {}
+  tr.pending = false
+  tr.removeAllListeners()
+  tr.setMaxListeners(0)
+  info(`Add listeners to torrent ${tr.infoHash || tr.token || tr.origin}`)
+  // tr.on('download', throttle(() => {
+  //   ipcRenderer.send('webtorrent-data', torrentToJson(tr))
+  // }))
+  tr.on('done', () => onDone(tr))
+  tr.on('ready', () => onReady(tr))
+  tr.on('metadata', () => onMetadata(tr, conf))
+  tr.on('infoHash', infoHash => {
+    onInfoHash(infoHash, tr, conf, isSeeding)
+  })
+  tr.on('warning', () => {})
+  tr.on('error', e => {
+    console.log('Torrent error', e, conf)
+    ipcRenderer.send('webtorrent-error', torrentToJson(tr), e.message)
+  })
+  const abProtocol = useAlphabizProtocol(client, tr)
+  tr.on('wire', wire => onWire(wire, tr, abProtocol))
+  tr.on('discovery', () => {
+    if (tr.discovery) {
+      info('start discovery')
+      tr.trackerMap = new TrackerMap()
+      // init map
+      tr.discovery._announce.forEach(url => {
+        verbose('Discovered', url)
+        tr.trackerMap.set(url, { status: 'connecting' })
+        if (!url.startsWith('ws')) {
+          if (url.match(/(\d{1,3}\.){3}\d{1,3}/)) {
+            // ipv4 only
+            return
+          }
+          tr.trackerMap.set(url + '@6', { status: 'connecting' })
+        }
+      })
+      tr.discovery.tracker.on('warning', (error, url, family) => {
+        verbose('tracker warning', url, error.message, family)
+        if (!url) return console.warn('No emitted url', error)
+        if (family === 6) {
+          // info('ipv6 tracker error', url)
+          url = url + '@6'
+        }
+        tr.trackerMap.set(url, {
+          status: 'error',
+          message: utils.parseTrackerWarning(error.message)
+        })
+      })
+      // tr.discovery.tracker.on('peer', (...args) => {
+      //   info('tracker peer', args)
+      // })
+      tr.discovery.tracker.on('update', (info, url, family) => {
+        verbose('tracker update', url, info)
+        if (!url) return console.warn('No emitted url', info)
+        if (family === 6) {
+          // info('ipv6 tracker', url)
+          url = url + '@6'
+        }
+        tr.trackerMap.set(url, {
+          status: 'updated',
+          info
+        })
+      })
+      // tr.discovery.tracker.on('scrape', (...args) => {
+      //   info('tracker scrape', args)
+      // })
+      // tr.addTracker = url => utils.addTracker(tr, url)
+      // tr.removeTracker = url => utils.removeTracker(tr, url)
+      if (conf.customTrackers) {
+        for (const tracker of conf.customTrackers) {
+          addTracker(tr, tracker)
+        }
+      }
+    } else {
+      info('no discovery')
+    }
+  })
+}
+/**
+ * @param { string } token
+ * @param { TorrentInfo } conf
+ * @param { Function } [cb]
+ */
+const addTorrent = (token, conf, cb) => {
+  verbose('Add torrent', token, conf)
+  if (conf.isSeeding && conf.progress === 1) return seedTorrent(token, conf.file, conf)
+  if (conf.infoHash) {
+    const matched = conf.infoHash.match(/btih:([^&]*)/)
+    const _hash = (matched && matched[1]) || conf.infoHash
+    if (_hash && client.get(_hash)) {
+      info('exist', client.get(_hash))
+      return ipcRenderer.send('webtorrent-existed', _hash)
+    }
+  }
+  if (conf.origin) {
+    if (locked.has(conf.origin)) {
+      info('origin lock', conf.origin)
+      return locked.delete(conf.origin)
+    } else {
+      locked.add(conf.origin)
+    }
+  }
+  if (conf.token !== conf.origin) {
+    if (locked.has(conf.token)) {
+      info('token lock', conf.token)
+      info(locked)
+      return locked.delete(conf.token)
+    } else {
+      locked.add(conf.token)
+    }
+  }
+  const add = () => {
+    const torrentId = (conf.torrentPath && fs.existsSync(conf.torrentPath))
+      ? conf.torrentPath
+      : fs.existsSync(conf.token || conf.origin)
+        ? conf.token || conf.origin
+        : conf.infoHash
+    info(torrentId)
+    const tr = client.add(torrentId, {
+      path: conf.path || conf.downloadDirectory,
+      store: FSChunkStore,
+      storeOpts: {
+        postTitle: conf.postTitle || ''
+      },
+      storeCacheSlots: 1,
+      strategy: 'sequential',
+      maxWebConns: client.maxConns,
+      // skipVerify: true,
+      announce: [...(conf.trackers || []), ...WEBTORRENT_ANNOUCEMENT]
+    })
+    tr.token = token
+    tr.origin = conf.infoHash || conf.token || conf.origin
+    tr.createdTime = conf.createdTime || Date.now()
+    tr.usedTime = conf.usedTime || 0
+    if (conf.fromPost) tr.fromPost = conf.fromPost
+    if (conf.postTitle) tr.postTitle = conf.postTitle
+    if (conf.name) tr.name = conf.name
+    if (conf.subtitleList && conf.subtitleList.length) tr.subtitleList = conf.subtitleList
+    verbose('Torrent conf', tr)
+    addListeners(tr, conf)
+    verbose('Listener added')
+    tr.once('infoHash', () => {
+      locked.delete(conf.origin)
+      locked.delete(tr.infoHash)
+      locked.delete(conf.token)
+      if (cb) cb(tr)
+    })
+    if (conf.verifiedPieces) {
+      tr.once('metadata', () => {
+        // If torrent is larger than 200MB, skip verifying downloaded
+        // pieces. This makes webtorrent init much more faster.
+        // It is dangerous, but useful if we add so many torrents.
+        if (tr.length < 200_000_000) return
+        let ctr = 0
+        // Defaultly verify 20% of downloaded pieces
+        let rate = 0.2
+        // 10% if larger than 5G
+        if (tr.length > 5_000_000_000) rate = 0.1
+        // 5% if larger than 20G
+        if (tr.length > 20_000_000_000) rate = 0.05
+        if (tr.length > 50_000_000_000) rate = 0.01
+        if (tr.length > 100_000_000_000) rate = 0.005
+        conf.verifiedPieces.forEach(range => {
+          // tr._markVerified(index)
+          // If range is an array of [start, end]
+          if (Array.isArray(range)) {
+            const [start, end] = range
+            // The first and last pieces are verified. But for security
+            // reason, we skip these pieces in range.
+            for (let i = start + 1; i < end - 1; i++) {
+              // Randomly verify parts of downloaded pieces
+              // if (Math.random() > rate) tr._markVerified(i)
+              tr._markVerified(i)
+              ctr++
+            }
+          } else {
+            if (!isNaN(range)) {
+              tr._markVerified(range)
+              ctr++
+            }
+          }
+        })
+        info('mark verified', conf.verifiedPieces, ctr)
+      })
+    }
+  }
+  if (client.get(conf.infoHash)) {
+    client.remove(conf.infoHash, add)
+  } else if (client.torrents.some(torrent => torrent.token === token)) {
+    const tr = client.torrents.find(torrent => torrent.token === token)
+    if (tr) {
+      if (tr.infoHash) return cb && cb(tr)
+      tr.once('infoHash', () => cb && cb(tr))
+    } else {
+      return add()
+    }
+  } else add()
+}
+/** @param { string } infoHash */
+const stopTorrent = infoHash => {
+  if (locked.has(infoHash)) return
+  else locked.add(infoHash)
+  if (server && serverInfoHash === infoHash) {
+    server.destroy()
+    server = null
+    serverInfoHash = ''
+  }
+  const tr = client.get(infoHash)
+  if (tr && (tr.isSeeding || tr.done)) {
+    tr.completed = true
+  }
+  if (tr) {
+    ipcRenderer.send('webtorrent-finish-all-payments', torrentToJson(tr))
+    tr.destroy(() => {
+      locked.delete(infoHash)
+      ipcRenderer.send('webtorrent-stop', infoHash, tr.completed)
+    })
+  } else {
+    locked.delete(infoHash)
+    if (infoHash) {
+      const _tr = client.torrents.find(tr => tr.token === infoHash)
+      if (_tr) {
+        _tr.destroy(() => {
+          locked.delete(infoHash)
+          ipcRenderer.send('webtorrent-stop', infoHash, _tr.completed)
+        })
+      }
+    } else {
+      ipcRenderer.send('webtorrent-notfound', infoHash)
+    }
+  }
+  if (infoHashes.includes(infoHash)) {
+    infoHashes.splice(infoHashes.indexOf(infoHash), 1)
+  }
+  forceUpdateTorrent()
+}
+/**
+ * @param { string } infoHash
+ * @param { boolean } destroyStore
+ * @param { () => void } onDeleted
+ */
+const deleteTorrent = (infoHash, destroyStore, onDeleted) => {
+  if (locked.has(infoHash)) return
+  else locked.add(infoHash)
+  shouldDelete.push(infoHash)
+  if (server && serverInfoHash === infoHash) {
+    server.destroy()
+    server = null
+    serverInfoHash = ''
+  }
+  const tr = client.get(infoHash) || client.torrents.find(t => t.token === infoHash)
+  info('delete', infoHash, tr, destroyStore)
+  if (tr) {
+    tr.emit('deleted')
+    info('emit', tr.emit)
+    const filePaths = tr.files.length ? tr.files.map(i => i.path) : tr.file || []
+    const publicPath = getPublicPath(filePaths)
+    tr.destroy({ destroyStore }, () => {
+      if (typeof onDeleted === 'function') onDeleted()
+      if (destroyStore) {
+        ipcRenderer.send('webtorrent-delete', tr.infoHash || infoHash, publicPath, filePaths)
+      } else {
+        ipcRenderer.send('webtorrent-delete', tr.infoHash || infoHash)
+      }
+      locked.delete(infoHash)
+      try {
+        client.remove(tr.infoHash)
+      } catch (_) { }
+    })
+  } else {
+    locked.delete(infoHash)
+    ipcRenderer.send('webtorrent-notfound', infoHash)
+  }
+  while (infoHashes.includes(infoHash)) {
+    infoHashes.splice(infoHashes.indexOf(infoHash), 1)
+  }
+  forceUpdateTorrent()
+}
+/**
+ * @param { string } token
+ * @param { string[] } files
+ * @param { TorrentInfo } options
+ * @param { boolean } isAutoUpload
+ * @param { function } callback
+ */
+const seedTorrent = (token, files, options, isAutoUpload = false, callback = null) => {
+  if (options.infoHash && client.get(options.infoHash)) return info('skip existed', options.infoHash)
+  const _torrentId = options.infoHash || options.token || options.origin || (Array.isArray(files) ? files[0] : files)
+  if (_torrentId) {
+    if (locked.has(_torrentId)) return
+    else locked.add(_torrentId)
+  }
+  let tr = null
+  const announce = [...(options.trackers || []), ...WEBTORRENT_ANNOUCEMENT]
+  const seedOpts = {
+    ...options,
+    store: FSChunkStore,
+    storeOpts: {
+      postTitle: options.postTitle || ''
+    },
+    storeCacheSlots: 1,
+    strategy: 'sequential',
+    maxWebConns: client.maxConns,
+    announce
+  }
+  if (options.infoHash && !options.upload && options.files.length) {
+    info('[seed] add torrent with token')
+    info(options)
+    tr = client.add(options.infoHash || options.token || options.origin, Object.assign(seedOpts, {
+      path: options.path || options.downloadDirectory,
+      skipVerify: options.progress === 1
+    }))
+  } else if (options.isSeeding && options.torrentPath && fs.existsSync(options.torrentPath)) {
+    info('[seed] add torrent with torrentPath')
+    tr = client.add(options.torrentPath, Object.assign(seedOpts, {
+      path: options.path || options.downloadDirectory,
+      skipVerify: true
+    }))
+  } else if (options.isSeeding && options.magnetURI && !options.isUploadByFiles) {
+    info('[seed] add torrent with magnetURI')
+    tr = client.add(options.magnetURI, Object.assign(seedOpts, {
+      path: options.path || options.downloadDirectory,
+      skipVerify: true
+    }))
+    tr.upload = true
+    tr.isSeeding = true
+  } else {
+    info('[seed] Seed torrent with files', !!options.infoHash, options)
+    const uploadTasks = client.torrents.filter(tr => tr.progress === 1)
+    const uploadingFiles = uploadTasks.reduce((all, tr) => {
+      const files = tr.files.map(f => f.path)
+      all.push(...files)
+      return all
+    }, [])
+    if (files.some(file => {
+      return uploadingFiles.includes(file)
+    })) {
+      ipcRenderer.send('webtorrent-seed-error', 'task_exists')
+    }
+    tr = client.seed(files, Object.assign(seedOpts, {
+      skipVerify: !!options.infoHash,
+      onProgress (current, total) {
+        // info('onprogress', current, total, current / total)
+        tr.verifyStatus = { current, total }
+      }
+    }))
+    tr.isUploadByFiles = true
+  }
+  info('seedTorrent', options, tr, files)
+  if (options.name) tr.name = options.name
+  tr.isAutoUpload = isAutoUpload
+  tr.token = token
+  tr.isSeeding = true
+  tr.upload = true
+  tr.paused = false
+  tr.file = files
+  tr.createdTime = options.createdTime || Date.now()
+  addListeners(tr, options, true)
+  tr.once('infoHash', () => {
+    locked.delete(_torrentId)
+    if (callback) callback()
+  })
+  tr.once('metadata', () => {
+    ipcRenderer.send('webtorrent-seed', torrentToJson(tr))
+  })
+  // The torrent to seed may computing hashes after torrent deleted
+  tr.once('deleted', () => {
+    // info('torrent deleted')
+    if (seedOpts.onProgress) {
+      seedOpts.onProgress._destroyed = true
+    }
+  })
+  return tr
+}
+
+const getTorrent = () => {
+  const torrents = client.torrents.map(i => torrentToJson(i))
+  info(torrents)
+  return ipcRenderer.send('webtorrent-list', torrents)
+}
+
+/**
+ * @param { Object } conf
+ * @param { 'low'|'mid'|'high' } conf.level
+ */
+const setThrottleGroup = ({ infoHash, peerId, subId, level }) => {
+  const tr = client.get(infoHash)
+  if (!tr) {
+    info('not found', infoHash)
+    ipcRenderer.send('webtorrent-set-throttle', {
+      code: -1,
+      message: 'Torrent Not Found'
+    })
+    return null
+  }
+  let peer = null, error = null
+  for (const wire of tr.wires) {
+    if (subId ? wire.remoteSub === subId : wire.peerId === peerId) {
+      peer = wire
+      try {
+        wire._setThrottleGroup(level)
+      } catch (e) {
+        error = { code: -1, message: e.message }
+      }
+      break
+    }
+  }
+  if (!peer) {
+    ipcRenderer.send('webtorrent-set-throttle', {
+      code: -1,
+      message: 'Peer Not Found'
+    })
+  } else if (error) ipcRenderer.send('webtorrent-set-throttle', error)
+  else {
+    ipcRenderer.send('webtorrent-set-throttle', {
+      code: 0,
+      message: 'success'
+    })
+  }
+  return peer
+}
+const saveTorrentFile = (infoHash, dir) => {
+  const channel = 'webtorrent-save-torrent'
+  const tr = client.get(infoHash)
+  if (!tr) return
+  if (!tr.torrentFile || !tr.name) {
+    return ipcRenderer.send(channel, {
+      code: -1,
+      message: 'Torrent Not Ready'
+    })
+  }
+  let torrentPath
+  try {
+    torrentPath = saveTorrentByName(dir, tr.name, tr.torrentFile)
+  } catch (error) {
+    info('Refused to save torrent metadata', error)
+    return ipcRenderer.send(channel, {
+      code: -1,
+      message: 'Unable to save torrent metadata safely',
+      infoHash
+    })
+  }
+  ipcRenderer.send(channel, {
+    code: 0,
+    message: 'success',
+    infoHash,
+    torrentPath
+  })
+}
+
+/** @type { ReturnType<import('webtorrent/lib/server')>} */
+let server = null
+let serverInfoHash = ''
+/** @param { Torrent } tr */
+const startTorrentServer = tr => {
+  info('Start server', tr)
+  startServerInfoHash = ''
+  if (server) {
+    // should stop old server and start a new one
+    if (serverInfoHash === tr.infoHash) {
+      return ipcRenderer.send('webtorrent-server-ready', tr.infoHash, {
+        token: tr.token,
+        port: server.address().port
+      })
+    } else {
+      server.destroy()
+      server = null
+      serverInfoHash = ''
+    }
+  }
+  info('Create server', tr)
+  server = tr.createServer()
+  server.listen(0, () => {
+    const port = server.address().port
+    const info = {
+      token: tr.token,
+      port
+    }
+    ipcRenderer.send('webtorrent-server-ready', tr.infoHash, info)
+    const sendProgress = () => {
+      const progress = tr.files.map(f => {
+        const prog = []
+        for (let i = f._startPiece; i < f._endPiece; i++) {
+          prog.push(tr.pieces[i] === null ? 1 : 0)
+        }
+        return {
+          name: f.name,
+          path: f.path,
+          progress: prog
+        }
+      })
+      ipcRenderer.send('webtorrent-server-progress', tr.infoHash, progress)
+    }
+    setTimeout(sendProgress, 1000)
+    // We don't need to update progress very frequently, 5s is enough
+    const inter = setInterval(sendProgress, 5000)
+    server.once('close', () => clearInterval(inter))
+  })
+}
+const startServer = (infoHash, conf) => {
+  info('start server', infoHash, conf)
+  startServerInfoHash = infoHash
+  const tr = client.get(infoHash)
+  if (!tr) {
+    return addTorrent(conf.token || conf.infoHash, conf, () => {
+      return startServer(infoHash, conf)
+    })
+  }
+  if (tr.ready) {
+    info('tr ready. start server')
+    startTorrentServer(tr, conf)
+  } else {
+    tr.once('ready', () => startTorrentServer(tr, conf))
+  }
+}
+const stopServer = () => {
+  if (!server) return
+  server.destroy()
+  server = null
+  serverInfoHash = ''
+  info('Destroy server')
+}
+
+(function init () {
+  ipcRenderer.once('redirect-log', (e, logPath) => {
+    console.log('Write webtorrent logs to', logPath)
+    utils.useRedirectLogs(logPath)
+  })
+  ipcRenderer.on('add-torrent', (e, token, torrentInfo) => {
+    if (torrentInfo.magnetURI && !torrentInfo.torrentPath) {
+      const preloaded = preloader.loadCache(torrentInfo.magnetURI, torrentInfo.path)
+      if (preloaded) {
+        console.log('[Preload] Load cached task', preloaded)
+        torrentInfo.torrentPath = preloaded
+      } else {
+        console.log('Cannot find preloaded task for', torrentInfo)
+      }
+    }
+    return addTorrent(token, torrentInfo)
+  })
+  ipcRenderer.on('stop-torrent', (e, infoHash) => {
+    console.log('got stop', infoHash)
+    return stopTorrent(infoHash)
+  })
+  ipcRenderer.on('stop-all-uploading', (e, torrents) => {
+    torrents.forEach(tr => {
+      const t = client.torrents.find(i => {
+        if (i.infoHash && i.infoHash === tr.infoHash) return true
+        if (i.token && i.token === tr.token) return true
+        return false
+      })
+      if (t) t.destroy()
+    })
+  })
+  ipcRenderer.on('delete-all', (e, type, destroyStore, deleteAutoUpload) => {
+    shouldSendInfo = false
+    info('Delete all', type, destroyStore, deleteAutoUpload)
+    const toDeletes = client.torrents.filter(tr => {
+      if (type === 'all') return true
+      const isUpload = tr.upload || tr.progress === 1 || tr.isSeeding
+      if (type === 'upload') {
+        if (!deleteAutoUpload && tr.isAutoUpload) return false
+        return isUpload
+      }
+      return !isUpload
+    })
+    if (!toDeletes.length) {
+      shouldSendInfo = true
+      return
+    }
+    // ensure all torrents are deleted
+    let end = 0
+    toDeletes.forEach(tr => {
+      end++
+      info(tr.infoHash)
+      shouldDelete.push(tr.infoHash)
+      tr.removeAllListeners()
+      try {
+        deleteTorrent(tr.infoHash, destroyStore, () => {
+          if (shouldDelete.includes(tr.infoHash)) {
+            shouldDelete.splice(shouldDelete.indexOf(tr.infoHash), 1)
+          }
+          end--
+          if (end === 0) shouldSendInfo = true
+        })
+      } catch (e) { }
+    })
+    // avoid something go wrong
+    setTimeout(() => {
+      shouldSendInfo = true
+    }, 2000)
+  })
+  ipcRenderer.on('seed-torrent', (e, torrentInfo) => {
+    let { file, token, ...options } = torrentInfo
+    // for downloaded torrents
+    if (!file) file = torrentInfo.files.map(i => i.path)
+    console.log(torrentInfo)
+    if (!file.length) return ipcRenderer.send('seed-error')
+    if (!token) token = Math.random().toString().substr(2)
+    return seedTorrent(token, file, options)
+  })
+  ipcRenderer.on('seed-torrents', (e, confs) => {
+    info(`Seed ${confs.length} torrents`)
+    confs.forEach(conf => {
+      let { file, token, ...options } = conf
+      if (!file) file = conf.files.map(i => i.path)
+      if (!token) token = Math.random().toString().substring(2)
+      seedTorrent(token, file, { ...conf })
+    })
+  })
+  ipcRenderer.on('autoupload-files', async (e, files) => {
+    info('autoupload files', files)
+    Promise.all(files.map(file => {
+      info('Auto upload', file)
+      // if file is already uploaded, ignore it
+      if (client.torrents.some(/** @param { Torrent } tr */tr => {
+        return tr.files.some(f => {
+          return f.path === file
+        }) || (tr.file && tr.file.some && tr.file.some(f => f === file)) || tr.file === file
+      })) {
+        info(`${file} is already uploaded, skipped`)
+        return
+      }
+      return new Promise(resolve => {
+        seedTorrent(
+          'autoupload-' + path.basename(file),
+          [file],
+          { path: path.dirname(file) },
+          true,
+          resolve
+        )
+      })
+    })).then(() => {
+      info('autoupload complete')
+      ipcRenderer.send('autoupload-complete')
+    }).catch((error) => {
+      ipcRenderer.send('autoupload-complete', error.message || error)
+    })
+    // Call tr#destroy in torrents.forEach may cause undefined behavior
+    // since tr#destory will remove it from torrents
+    // Save references before destroy them
+    const toDestroy = []
+    client.torrents.forEach(/** @param { Torrent } tr */ tr => {
+      if (tr.isAutoUpload && tr.ready) {
+        if (!tr.files.some(f => files.includes(f.path))) {
+          // remove deleted file
+          info(`${tr.infoHash} has been deleted. Destroy`, tr.files.map(i => i.path))
+          // tr.destroy(() => {
+          //   ipcRenderer.send('webtorrent-delete', tr.infoHash)
+          // })
+          toDestroy.push(tr)
+        } else {
+          info(`${tr.infoHash} is kept alive`)
+        }
+      }
+    })
+    toDestroy.forEach(tr => {
+      tr.destroy(() => {
+        ipcRenderer.send('webtorrent-delete', tr.infoHash)
+      })
+    })
+  })
+  ipcRenderer.on('start-server', (e, { infoHash, conf }) => {
+    info('start server', infoHash, conf)
+    return startServer(infoHash, conf)
+  })
+  ipcRenderer.on('stop-server', () => stopServer())
+  ipcRenderer.on('delete-torrent', (e, infoHash, destroyStore) => {
+    return deleteTorrent(infoHash, destroyStore)
+  })
+  ipcRenderer.on('pend-torrent', (e, conf) => {
+    const tr = client.get(conf.infoHash)
+    if (infoHashes.includes(conf.infoHash)) {
+      infoHashes.splice(infoHashes.indexOf(conf.infoHash), 1)
+    }
+    info('Pend', conf.infoHash, tr)
+    if (tr) {
+      tr.removeAllListeners()
+      tr.destroy()
+      tr.pending = true
+      ipcRenderer.send('webtorrent-pending', torrentToJson(tr))
+    }
+  })
+  ipcRenderer.on('set-throttle-group', (e, { infoHash, peerId, subId, level }) => {
+    info(infoHash, peerId, subId, level)
+    setThrottleGroup({ infoHash, peerId, subId, level })
+  })
+  ipcRenderer.on('save-torrent-file', (e, infoHash, dir) => saveTorrentFile(infoHash, dir))
+  ipcRenderer.on('update-settings', (e, {
+    uploadSpeed,
+    downloadSpeed,
+    maximumConnectionsNum,
+    DHTlistenPort,
+    BTlistenPort,
+    payedUserShareRate,
+    secureOption,
+    libraryPreload,
+    showPreload
+  }) => {
+    // old versions use string, but now number
+    const dhtPort = parseInt(DHTlistenPort)
+    const torrentPort = parseInt(BTlistenPort)
+    info('Set client', {
+      uploadSpeed,
+      downloadSpeed,
+      maximumConnectionsNum,
+      dhtPort,
+      torrentPort,
+      payedUserShareRate,
+      secureOption,
+      libraryPreload,
+      showPreload
+    })
+    if (payedUserShareRate) {
+      const shareRate = Number(payedUserShareRate) || 0.7
+      localStorage.setItem('payedUserShareRate', shareRate.toString())
+    }
+    if (uploadSpeed) {
+      const limit = speedLimit(uploadSpeed)
+      localStorage.setItem('uploadSpeed', limit.toString())
+    }
+    const shareRate = Number(localStorage.getItem('payedUserShareRate')) || 0.7
+    const limit = parseInt(localStorage.getItem('uploadSpeed'))
+    if (!isNaN(shareRate) && !isNaN(limit)) {
+      if (limit === -1) client.throttleUpload(-1)
+      else client.throttleUpload(limit, shareRate)
+    }
+    if (downloadSpeed) {
+      const limit = speedLimit(downloadSpeed)
+      client.throttleDownload(limit)
+      localStorage.setItem('downloadSpeed', limit.toString())
+    }
+    if (maximumConnectionsNum) {
+      client.maxConns = maximumConnectionsNum
+      localStorage.setItem('maximumConnectionsNum', maximumConnectionsNum.toString())
+    }
+    let shouldRestart = false
+    if (dhtPort && dhtPort !== parseInt(localStorage.getItem('dhtPort'))) {
+      shouldRestart = true
+      localStorage.setItem('dhtPort', dhtPort.toString())
+    }
+    if (torrentPort && torrentPort !== parseInt(localStorage.getItem('torrentPort'))) {
+      shouldRestart = true
+      localStorage.setItem('torrentPort', torrentPort.toString())
+    }
+    if (typeof secureOption === 'string') {
+      localStorage.setItem('webtorrent-secure', secureOption)
+      setSecure(secureOption)
+      info('set secure', secureOption)
+    }
+    if (shouldRestart) {
+      // process.exit(0)
+      // process.exit makes devtools unaccessable, use reload instead
+      location.reload()
+    }
+    // Preload config
+    // `libraryPreload` may be `undefined` if user did not change it at this time
+    if (libraryPreload === true) preloader.enable()
+    else if (libraryPreload === false) preloader.disable()
+    // `showPreload` may be `undefined` that should not update `sendPreloadTasks`
+    if (showPreload === true) {
+      sendPreloadTasks = true
+      localStorage.setItem('send-preload-tasks', '1')
+    } else if (showPreload === false) {
+      sendPreloadTasks = false
+      localStorage.setItem('send-preload-tasks', '0')
+    }
+  })
+  ipcRenderer.on('reset-torrent', () => {
+    info('reset')
+    shouldSendInfo = false
+    Promise.all(client.torrents.map(tr => new Promise(resolve => {
+      tr.removeAllListeners()
+      tr.destroy({ destroyStore: true }, resolve)
+    })))
+      .then(() => ipcRenderer.send('webtorrent-reset'))
+      .catch(() => ipcRenderer.send('webtorrent-reset-error'))
+      .finally(() => {
+        info('resetted')
+        client.torrents.length = 0
+        shouldSendInfo = true
+      })
+  })
+  ipcRenderer.on('add-tracker', (e, { infoHash, url }) => {
+    info('add-tracker', infoHash, url)
+    addTracker(infoHash, url)
+  })
+  ipcRenderer.on('remove-tracker', (e, { infoHash, url }) => {
+    info('remove-tracker', infoHash, url)
+    removeTracker(infoHash, url)
+  })
+  ipcRenderer.on('force-exit', () => process.exit(0))
+  setInterval(() => {
+    if (process.memoryUsage().rss / 1_000_000_000 > 3.5) {
+      info('exit for memory reason')
+      process.exit(0)
+    }
+  }, 60000)
+
+  initClient(0)
+  // ipcRenderer.send('webtorrent-initted')
+  window.addEventListener('error', e => {
+    info(e.message || e)
+    // ipcRenderer.send('webtorrent-window-error', e.error && e.error.message || e.message)
+    return true
+  })
+  ipcRenderer.on('before-quit', () => {
+    natPorts.forEach(port => {
+      natTraversal.portUnMapping(port)
+    })
+  })
+  if (typeof window !== 'undefined') {
+    window.addEventListener('beforeunload', () => {
+      natPorts.forEach(port => {
+        natTraversal.portUnMapping(port)
+      })
+    })
+  }
+})()

--- a/i18n/check.js
+++ b/i18n/check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { readdirSync, statSync, existsSync, writeFileSync, readFileSync } = require('fs')
+const { closeSync, constants, existsSync, fstatSync, ftruncateSync, openSync, readFileSync, readdirSync, statSync, writeFileSync, writeSync } = require('fs')
 const { resolve } = require('path')
 const exit = reason => {
   console.log(reason)
@@ -12,51 +12,83 @@ const example = require('./example/translations.json')
 const check = (lang, overwrite = false) => {
   if (lang === 'example') return
   const file = resolve(__dirname, lang, 'translations.json')
-  if (!existsSync(file)) {
+  let fileFd
+  let data
+  try {
+    const noFollow = constants.O_NOFOLLOW || 0
+    const access = overwrite ? constants.O_RDWR : constants.O_RDONLY
+    fileFd = openSync(file, access | noFollow)
+    if (!fstatSync(fileFd).isFile()) {
+      throw new Error(`Expected a regular translations file: ${file}`)
+    }
+    data = JSON.parse(readFileSync(fileFd, 'utf-8'))
+  } catch (error) {
+    if (fileFd !== undefined) closeSync(fileFd)
+    if (error.code !== 'ENOENT') throw error
     console.log(`Cannot get translations.json from ${lang}`)
     if (overwrite) {
-      writeFileSync(file, JSON.stringify(example, null, 2))
-      console.log(`(Overwrite) Write translations.json example file.`)
+      let newFileFd
+      try {
+        const noFollow = constants.O_NOFOLLOW || 0
+        newFileFd = openSync(
+          file,
+          constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | noFollow,
+          0o600
+        )
+        writeFileSync(newFileFd, JSON.stringify(example, null, 2), 'utf-8')
+        console.log(`(Overwrite) Write translations.json example file.`)
+      } catch (createError) {
+        if (createError.code === 'EEXIST') {
+          throw new Error(`translations.json appeared while checking ${lang}; run the check again.`)
+        }
+        throw createError
+      } finally {
+        if (newFileFd !== undefined) closeSync(newFileFd)
+      }
     }
     return
   }
-  const data = JSON.parse(readFileSync(file, 'utf-8'))
-  let changed = false
-  let missingVar = false
-  for (const key in example) {
-    const value = example[key]
-    if (!(key in data)) {
-      console.log(`[${lang}] Missing key "${key}".${overwrite ? ` The key is added and you should translate it.` : ''}`)
-      data[key] = value
-      changed = true
-    }
-    const trans = data[key]
-    const matches = value.match(/\{.+?}/g)
-    if (!matches) continue
-    matches.forEach(s => {
-      if (!trans.includes(s)) {
-        console.log(`[${lang}] key "${key}" does not have variable "${s}"`)
-        missingVar = true
+  try {
+    let changed = false
+    let missingVar = false
+    for (const key in example) {
+      const value = example[key]
+      if (!(key in data)) {
+        console.log(`[${lang}] Missing key "${key}".${overwrite ? ` The key is added and you should translate it.` : ''}`)
+        data[key] = value
+        changed = true
       }
-    })
-  }
-  for (const key in data) {
-    if (!(key in example)) {
-      console.log(`[${lang}] The existed key "${key}" is not in example json.${overwrite ? ' This key will be removed.' : ''}`)
-      delete data[key]
-      changed = true
+      const trans = data[key]
+      const matches = value.match(/\{.+?}/g)
+      if (!matches) continue
+      matches.forEach(s => {
+        if (!trans.includes(s)) {
+          console.log(`[${lang}] key "${key}" does not have variable "${s}"`)
+          missingVar = true
+        }
+      })
     }
-  }
-  if (missingVar) {
-    console.log(`[${lang}] Some of vars are missing and you should change them manually.`)
-  } else if (changed) {
-    console.log(`[${lang}] Found something should be changed.`)
-    if (overwrite) {
-      writeFileSync(file, JSON.stringify(data, null, 2))
-      console.log(`[${lang}] The translations.json file was changed. Check the file for more infomations.`)
+    for (const key in data) {
+      if (!(key in example)) {
+        console.log(`[${lang}] The existed key "${key}" is not in example json.${overwrite ? ' This key will be removed.' : ''}`)
+        delete data[key]
+        changed = true
+      }
     }
-  } else {
-    console.log(`[${lang}] This language is perfectly ready for publish!`)
+    if (missingVar) {
+      console.log(`[${lang}] Some of vars are missing and you should change them manually.`)
+    } else if (changed) {
+      console.log(`[${lang}] Found something should be changed.`)
+      if (overwrite) {
+        ftruncateSync(fileFd, 0)
+        writeSync(fileFd, JSON.stringify(data, null, 2), 0, 'utf-8')
+        console.log(`[${lang}] The translations.json file was changed. Check the file for more infomations.`)
+      }
+    } else {
+      console.log(`[${lang}] This language is perfectly ready for publish!`)
+    }
+  } finally {
+    closeSync(fileFd)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "security:scan": "node scripts/security/scan-credentials.js",
     "security:test-scan": "node scripts/security/test-credential-scan.js",
     "security:test-appx": "node scripts/security/test-appx-signing.js",
-    "security:test-appx:forge": "node scripts/security/test-appx-signing.js --forge-config"
+    "security:test-appx:forge": "node scripts/security/test-appx-signing.js --forge-config",
+    "security:test-codeql": "node scripts/security/test-codeql-hardening.js"
   },
   "dependencies": {
     "big-json": "^3.2.0",

--- a/public/torrent-file.js
+++ b/public/torrent-file.js
@@ -1,0 +1,121 @@
+(() => {
+  'use strict'
+
+  const crypto = require('crypto')
+  const fs = require('fs')
+  const path = require('path')
+
+  const INFO_HASH_PATTERN = /^(?:[a-f\d]{40}|[a-f\d]{64})$/i
+
+  function writeUniqueSibling (filePath, contents) {
+    const parsedPath = path.parse(filePath)
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const suffix = crypto.randomBytes(8).toString('hex')
+      const candidate = path.join(
+        parsedPath.dir,
+        `${parsedPath.name}.${suffix}${parsedPath.ext}`
+      )
+      try {
+        fs.writeFileSync(candidate, contents, { flag: 'wx', mode: 0o600 })
+        return candidate
+      } catch (error) {
+        if (error.code !== 'EEXIST') throw error
+      }
+    }
+    throw new Error('Unable to create a unique torrent file')
+  }
+
+  function writeFileOnce (filePath, torrentFile) {
+    const contents = Buffer.from(torrentFile)
+    try {
+      fs.writeFileSync(filePath, contents, { flag: 'wx', mode: 0o600 })
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error
+
+      let existingFd
+      try {
+        const noFollow = fs.constants.O_NOFOLLOW
+        if (!noFollow) {
+          return writeUniqueSibling(filePath, contents)
+        }
+        existingFd = fs.openSync(filePath, fs.constants.O_RDONLY | noFollow)
+        if (!fs.fstatSync(existingFd).isFile()) {
+          throw new Error(`Refusing to use a non-regular torrent file: ${filePath}`)
+        }
+        if (!fs.readFileSync(existingFd).equals(contents)) {
+          throw new Error(`Refusing to replace a different torrent file: ${filePath}`)
+        }
+      } finally {
+        if (existingFd !== undefined) fs.closeSync(existingFd)
+      }
+    }
+    return filePath
+  }
+
+  function prepareDirectory (directory) {
+    const resolvedDirectory = path.resolve(directory)
+    fs.mkdirSync(resolvedDirectory, { recursive: true, mode: 0o700 })
+    const realDirectory = fs.realpathSync(resolvedDirectory)
+    if (!fs.statSync(realDirectory).isDirectory()) {
+      throw new Error(`Expected a torrent directory: ${resolvedDirectory}`)
+    }
+    return realDirectory
+  }
+
+  function saveTorrentByInfoHash (directory, infoHash, torrentFile) {
+    const normalizedInfoHash = String(infoHash).toLowerCase()
+    if (!INFO_HASH_PATTERN.test(normalizedInfoHash)) {
+      throw new Error('Invalid torrent info hash')
+    }
+    const resolvedDirectory = prepareDirectory(directory)
+    return writeFileOnce(
+      path.join(resolvedDirectory, `${normalizedInfoHash}.torrent`),
+      torrentFile
+    )
+  }
+
+  function sanitizeTorrentName (name) {
+    let safeName = String(name)
+      .replace(/[\u0000-\u001f\u007f<>:"/\\|?*]/g, '_')
+      .replace(/^\.+/, '_')
+      .replace(/[. ]+$/g, '')
+    if (/^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)/i.test(safeName)) {
+      safeName = `_${safeName}`
+    }
+    let byteLength = 0
+    let truncatedName = ''
+    for (const character of safeName) {
+      const characterBytes = Buffer.byteLength(character, 'utf-8')
+      if (byteLength + characterBytes > 200) break
+      byteLength += characterBytes
+      truncatedName += character
+    }
+    safeName = truncatedName.replace(/[. ]+$/g, '')
+    if (!safeName) throw new Error('Invalid torrent name')
+    return safeName
+  }
+
+  function saveTorrentByName (directory, name, torrentFile) {
+    const resolvedDirectory = prepareDirectory(directory)
+    const torrentPath = path.resolve(
+      resolvedDirectory,
+      `${sanitizeTorrentName(name)}.torrent`
+    )
+    if (path.dirname(torrentPath) !== resolvedDirectory) {
+      throw new Error('Invalid torrent path')
+    }
+    return writeFileOnce(torrentPath, torrentFile)
+  }
+
+  Object.defineProperty(globalThis, 'alphabizTorrentFile', {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+    value: Object.freeze({
+      INFO_HASH_PATTERN,
+      sanitizeTorrentName,
+      saveTorrentByInfoHash,
+      saveTorrentByName
+    })
+  })
+})()

--- a/public/webtorrent-preload.js
+++ b/public/webtorrent-preload.js
@@ -2,6 +2,10 @@ const { ipcRenderer } = require('electron')
 const { existsSync, writeFileSync, readFileSync, mkdirSync, cpSync, statSync, rmSync } = require('fs')
 const { resolve, dirname } = require('path')
 const WebTorrent = require('webtorrent')
+const { saveTorrentByInfoHash } = globalThis.alphabizTorrentFile || {}
+if (typeof saveTorrentByInfoHash !== 'function') {
+  throw new Error('Torrent file security boundary is not loaded')
+}
 import utils from './webtorrent-utils.js'
 const { torrentToJson } = utils
 
@@ -145,10 +149,18 @@ const queueTask = ({ url, path, origin, postTitle }) => {
   torrent.on('ready', () => {
     clearTimeout(timer)
     if (!torrent.torrentFile || !torrent.infoHash) return
-    const torrentPath = resolve(dirname(path), `../torrents/${torrent.infoHash}.torrent`)
-    if (!existsSync(dirname(torrentPath))) mkdirSync(dirname(torrentPath), { recursive: true })
-    if (!existsSync(torrentPath)) {
-      writeFileSync(torrentPath, torrent.torrentFile)
+    const torrentsDir = resolve(dirname(path), '../torrents')
+    let torrentPath
+    try {
+      torrentPath = saveTorrentByInfoHash(
+        torrentsDir,
+        torrent.infoHash,
+        torrent.torrentFile
+      )
+    } catch (error) {
+      console.error('[Preload] Refused to save torrent metadata', error)
+      ipcRenderer.send('preload-failed', origin)
+      return
     }
     if (!preloadTasks.has(url)) {
       preloadTasks.set(url, {

--- a/public/webtorrent.html
+++ b/public/webtorrent.html
@@ -28,6 +28,7 @@
     should always in console of the renderer process.
   </div>
   <!-- <script src="wt-extention.js"></script> -->
+  <script src="torrent-file.js"></script>
   <script src="webtorrent.js" type="module"></script>
 </body>
 

--- a/public/webtorrent.js
+++ b/public/webtorrent.js
@@ -4,6 +4,10 @@ const { ipcRenderer } = require('electron')
 const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
+const { saveTorrentByName } = globalThis.alphabizTorrentFile || {}
+if (typeof saveTorrentByName !== 'function') {
+  throw new Error('Torrent file security boundary is not loaded')
+}
 const { setSecure } = require('webtorrent/lib/peer')
 // const diskusage = require('diskusage')
 const FSChunkStore = require('fs-chunk-store')
@@ -953,17 +957,17 @@ const saveTorrentFile = (infoHash, dir) => {
       message: 'Torrent Not Ready'
     })
   }
-  const torrentPath = path.resolve(dir, `${tr.name}.torrent`)
-  if (fs.existsSync(torrentPath)) {
+  let torrentPath
+  try {
+    torrentPath = saveTorrentByName(dir, tr.name, tr.torrentFile)
+  } catch (error) {
+    info('Refused to save torrent metadata', error)
     return ipcRenderer.send(channel, {
-      code: 0,
-      message: 'success',
-      infoHash,
-      torrentPath
+      code: -1,
+      message: 'Unable to save torrent metadata safely',
+      infoHash
     })
   }
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-  fs.writeFileSync(torrentPath, tr.torrentFile)
   ipcRenderer.send(channel, {
     code: 0,
     message: 'success',

--- a/scripts/security/test-codeql-hardening.js
+++ b/scripts/security/test-codeql-hardening.js
@@ -224,23 +224,13 @@ try {
     createYarnInvocation({
       arch: 'x64',
       platform: 'win32',
-      runtimePlatform: 'win32',
-      commandInterpreter: 'C:\\Windows\\System32\\cmd.exe'
+      runtimePlatform: 'win32'
     }),
     {
       command: 'C:\\Windows\\System32\\cmd.exe',
       args: ['/d', '/s', '/c', 'yarn.cmd', 'make:win', '--arch', 'x64'],
       options: { shell: false, windowsHide: true }
     }
-  )
-  assert.throws(
-    () => createYarnInvocation({
-      arch: 'x64',
-      platform: 'win32',
-      runtimePlatform: 'win32',
-      commandInterpreter: 'powershell.exe'
-    }),
-    /Invalid Windows command interpreter/
   )
   assert.deepStrictEqual(createGitRestoreInvocation(), {
     command: 'git',

--- a/scripts/security/test-codeql-hardening.js
+++ b/scripts/security/test-codeql-hardening.js
@@ -1,0 +1,415 @@
+#!/usr/bin/env node
+'use strict'
+
+const assert = require('assert')
+const { execFileSync, spawnSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const vm = require('vm')
+const {
+  createGitRestoreInvocation,
+  createYarnInvocation,
+  validateBuildTarget
+} = require('../../build-scripts/common/command-boundary')
+const escapeRegExp = require('../../test/utils/escapeRegExp')
+
+const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alphabiz-codeql-test-'))
+const makeScript = path.resolve(__dirname, '../../build-scripts/common/make.js')
+const torrentHelperPath = path.resolve(__dirname, '../../public/torrent-file.js')
+const webTorrentHtmlPath = path.resolve(__dirname, '../../public/webtorrent.html')
+
+try {
+  const torrentHelperSource = fs.readFileSync(torrentHelperPath, 'utf-8')
+  const rendererContext = vm.createContext({ Buffer, require })
+  vm.runInContext(
+    torrentHelperSource,
+    rendererContext,
+    { filename: torrentHelperPath }
+  )
+  const {
+    sanitizeTorrentName,
+    saveTorrentByInfoHash,
+    saveTorrentByName
+  } = rendererContext.alphabizTorrentFile
+  assert.strictEqual(typeof saveTorrentByInfoHash, 'function')
+  assert.strictEqual(typeof saveTorrentByName, 'function')
+  assert(Object.isFrozen(rendererContext.alphabizTorrentFile))
+  assert.strictEqual(
+    Object.getOwnPropertyDescriptor(rendererContext, 'alphabizTorrentFile').writable,
+    false
+  )
+
+  const webTorrentHtml = fs.readFileSync(webTorrentHtmlPath, 'utf-8')
+  const helperScriptPosition = webTorrentHtml.indexOf('<script src="torrent-file.js"></script>')
+  const workerScriptPosition = webTorrentHtml.indexOf('<script src="webtorrent.js" type="module"></script>')
+  assert(helperScriptPosition >= 0)
+  assert(workerScriptPosition > helperScriptPosition)
+
+  const noFollowFs = {
+    ...fs,
+    constants: { ...fs.constants, O_NOFOLLOW: 0 }
+  }
+  const noFollowContext = vm.createContext({
+    Buffer,
+    require: moduleName => moduleName === 'fs' ? noFollowFs : require(moduleName)
+  })
+  vm.runInContext(torrentHelperSource, noFollowContext, {
+    filename: torrentHelperPath
+  })
+  const noFollowDirectory = path.join(testRoot, 'no-follow-torrents')
+  const noFollowHash = 'c'.repeat(40)
+  const noFollowFirstPath = noFollowContext.alphabizTorrentFile.saveTorrentByInfoHash(
+    noFollowDirectory,
+    noFollowHash,
+    'first'
+  )
+  const noFollowSecondPath = noFollowContext.alphabizTorrentFile.saveTorrentByInfoHash(
+    noFollowDirectory,
+    noFollowHash,
+    'second'
+  )
+  assert.notStrictEqual(noFollowSecondPath, noFollowFirstPath)
+  assert.strictEqual(path.dirname(noFollowSecondPath), fs.realpathSync(noFollowDirectory))
+  assert.strictEqual(fs.readFileSync(noFollowFirstPath, 'utf-8'), 'first')
+  assert.strictEqual(fs.readFileSync(noFollowSecondPath, 'utf-8'), 'second')
+
+  for (const artifact of [
+    'torrent-file.js',
+    'webtorrent-preload.js',
+    'webtorrent.html',
+    'webtorrent.js'
+  ]) {
+    const canonicalArtifact = fs.readFileSync(
+      path.resolve(__dirname, '../../public', artifact)
+    )
+    for (const packagedDirectory of [
+      '../../dist/spa',
+      '../../dist/electron/UnPackaged'
+    ]) {
+      assert.deepStrictEqual(
+        fs.readFileSync(path.resolve(__dirname, packagedDirectory, artifact)),
+        canonicalArtifact,
+        `${artifact} must match the packaged copy in ${packagedDirectory}`
+      )
+    }
+  }
+
+  const torrentDirectory = path.join(testRoot, 'torrents')
+  const infoHash = 'a'.repeat(40)
+  const torrentContents = Buffer.from('torrent-fixture')
+  const torrentPath = saveTorrentByInfoHash(
+    torrentDirectory,
+    infoHash,
+    torrentContents
+  )
+  assert.strictEqual(path.dirname(torrentPath), fs.realpathSync(torrentDirectory))
+  assert.deepStrictEqual(fs.readFileSync(torrentPath), torrentContents)
+  if (process.platform !== 'win32') {
+    assert.strictEqual(fs.statSync(torrentPath).mode & 0o777, 0o600)
+  }
+  if (fs.constants.O_NOFOLLOW) {
+    assert.strictEqual(
+      saveTorrentByInfoHash(torrentDirectory, infoHash, torrentContents),
+      torrentPath
+    )
+    assert.throws(
+      () => saveTorrentByInfoHash(torrentDirectory, infoHash, 'different'),
+      /different torrent file/
+    )
+  } else {
+    const repeatedPath = saveTorrentByInfoHash(
+      torrentDirectory,
+      infoHash,
+      torrentContents
+    )
+    assert.notStrictEqual(repeatedPath, torrentPath)
+    assert.strictEqual(path.dirname(repeatedPath), fs.realpathSync(torrentDirectory))
+    assert.deepStrictEqual(fs.readFileSync(repeatedPath), torrentContents)
+    const differentPath = saveTorrentByInfoHash(
+      torrentDirectory,
+      infoHash,
+      'different'
+    )
+    assert.notStrictEqual(differentPath, torrentPath)
+    assert.notStrictEqual(differentPath, repeatedPath)
+    assert.strictEqual(fs.readFileSync(differentPath, 'utf-8'), 'different')
+  }
+  assert.throws(
+    () => saveTorrentByInfoHash(torrentDirectory, '../escape', torrentContents),
+    /Invalid torrent info hash/
+  )
+
+  if (process.platform !== 'win32') {
+    const symlinkHash = 'b'.repeat(40)
+    const outsidePath = path.join(testRoot, 'outside.torrent')
+    fs.writeFileSync(outsidePath, 'outside')
+    fs.symlinkSync(
+      outsidePath,
+      path.join(torrentDirectory, `${symlinkHash}.torrent`)
+    )
+    assert.throws(
+      () => saveTorrentByInfoHash(torrentDirectory, symlinkHash, torrentContents)
+    )
+    assert.strictEqual(fs.readFileSync(outsidePath, 'utf-8'), 'outside')
+  }
+
+  assert.strictEqual(sanitizeTorrentName('../episode'), '__episode')
+  assert.strictEqual(sanitizeTorrentName('episode?.mp4.'), 'episode_.mp4')
+  assert.strictEqual(sanitizeTorrentName('CON'), '_CON')
+  assert.strictEqual(sanitizeTorrentName('lpt1.backup'), '_lpt1.backup')
+  assert(Buffer.byteLength(sanitizeTorrentName('剧'.repeat(100)), 'utf-8') <= 200)
+  const namedPath = saveTorrentByName(
+    torrentDirectory,
+    '../../absolute\\escape',
+    torrentContents
+  )
+  assert.strictEqual(path.dirname(namedPath), fs.realpathSync(torrentDirectory))
+  assert.deepStrictEqual(fs.readFileSync(namedPath), torrentContents)
+
+  const releasePattern = new RegExp(
+    `^${escapeRegExp('alpha.biz+desktop')}-${escapeRegExp('0.4.0-beta.1')}\\.${escapeRegExp('dmg')}$`
+  )
+  assert(releasePattern.test('alpha.biz+desktop-0.4.0-beta.1.dmg'))
+  assert(!releasePattern.test('alphaXbiz+desktop-0.4.0-beta.1.dmg'))
+  assert(!releasePattern.test('alpha.biz+desktop-0.4.0-beta.1Xdmg'))
+
+  const entitlementsDirectory = path.join(testRoot, 'entitlements')
+  fs.mkdirSync(entitlementsDirectory, { mode: 0o700 })
+  execFileSync(process.execPath, [
+    path.resolve(__dirname, '../../build-scripts/macos/app/buildEntitlements.js'),
+    entitlementsDirectory
+  ], { stdio: 'ignore' })
+  const entitlementFiles = fs.readdirSync(entitlementsDirectory)
+  assert.deepStrictEqual(entitlementFiles.sort(), [
+    'entitlements.inherit.plist',
+    'entitlements.loginhelper.plist',
+    'entitlements.mas.plist'
+  ])
+  for (const file of entitlementFiles) {
+    if (process.platform !== 'win32') {
+      assert.strictEqual(
+        fs.statSync(path.join(entitlementsDirectory, file)).mode & 0o777,
+        0o600
+      )
+    }
+  }
+  assert.throws(() => execFileSync(process.execPath, [
+    path.resolve(__dirname, '../../build-scripts/macos/app/buildEntitlements.js'),
+    entitlementsDirectory
+  ], {
+    env: {
+      ...process.env,
+      NODE_OPTIONS: '--unhandled-rejections=warn'
+    },
+    stdio: 'ignore'
+  }))
+  assert.throws(() => execFileSync(process.execPath, [
+    path.resolve(__dirname, '../../build-scripts/macos/app/buildEntitlements.js')
+  ], { stdio: 'ignore' }))
+
+  assert.deepStrictEqual(validateBuildTarget('x64', 'linux'), {
+    arch: 'x64',
+    platform: 'linux'
+  })
+  assert.throws(
+    () => validateBuildTarget('x64;touch-pwned', 'linux'),
+    /Unsupported BUILD_ARCH/
+  )
+  assert.throws(
+    () => validateBuildTarget('x64', '--inspect'),
+    /Unsupported BUILD_PLATFORM/
+  )
+  assert.deepStrictEqual(
+    createYarnInvocation({
+      arch: 'x64',
+      platform: 'win32',
+      runtimePlatform: 'win32',
+      commandInterpreter: 'C:\\Windows\\System32\\cmd.exe'
+    }),
+    {
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'yarn.cmd', 'make:win', '--arch', 'x64'],
+      options: { shell: false, windowsHide: true }
+    }
+  )
+  assert.throws(
+    () => createYarnInvocation({
+      arch: 'x64',
+      platform: 'win32',
+      runtimePlatform: 'win32',
+      commandInterpreter: 'powershell.exe'
+    }),
+    /Invalid Windows command interpreter/
+  )
+  assert.deepStrictEqual(createGitRestoreInvocation(), {
+    command: 'git',
+    args: [
+      'restore',
+      '--worktree',
+      '--',
+      'build-scripts/windows/appx/template.xml',
+      'package.json'
+    ],
+    options: { shell: false }
+  })
+  if (process.platform === 'win32') {
+    const fakeBin = path.join(testRoot, 'fake-bin')
+    fs.mkdirSync(fakeBin)
+    fs.writeFileSync(
+      path.join(fakeBin, 'yarn.cmd'),
+      '@echo off\r\necho %*\r\n'
+    )
+    const invocation = createYarnInvocation({
+      arch: 'x64',
+      platform: 'win32',
+      runtimePlatform: process.platform
+    })
+    const actualWindowsSpawn = spawnSync(
+      invocation.command,
+      invocation.args,
+      {
+        ...invocation.options,
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${fakeBin};${process.env.PATH || ''}`
+        }
+      }
+    )
+    assert.strictEqual(actualWindowsSpawn.status, 0, actualWindowsSpawn.stderr)
+    assert.match(actualWindowsSpawn.stdout, /make:win --arch x64/)
+  }
+
+  const invalidArchitecture = spawnSync(process.execPath, [makeScript], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      BUILD_ARCH: 'x64;touch-pwned',
+      BUILD_PLATFORM: 'linux'
+    }
+  })
+  assert.notStrictEqual(invalidArchitecture.status, 0)
+  assert.match(invalidArchitecture.stderr, /Unsupported BUILD_ARCH/)
+
+  const invalidPlatform = spawnSync(process.execPath, [makeScript], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      BUILD_ARCH: 'x64',
+      BUILD_PLATFORM: '--inspect'
+    }
+  })
+  assert.notStrictEqual(invalidPlatform.status, 0)
+  assert.match(invalidPlatform.stderr, /Unsupported BUILD_PLATFORM/)
+
+  const validBoundary = spawnSync(process.execPath, [makeScript], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      BUILD_ARCH: 'x64',
+      BUILD_PLATFORM: 'linux'
+    }
+  })
+  assert.notStrictEqual(validBoundary.status, 0)
+  assert.match(validBoundary.stderr, /Require passing --make or --postmake/)
+  assert.doesNotMatch(validBoundary.stderr, /Unsupported BUILD_/)
+
+  execFileSync(process.execPath, ['-e', [
+    "const assert = require('assert')",
+    "const { getminversions } = require('./test/utils/modifyVersion')",
+    "getminversions().then(versions => {",
+    "  assert.deepStrictEqual(versions, {",
+    "    stable: '0.1.0',",
+    "    nightly: '0.1.0-nightly-202205301917',",
+    "    internal: '0.1.0-internal-202205301821'",
+    '  })',
+    '})'
+  ].join('\n')], {
+    cwd: path.resolve(__dirname, '../..'),
+    stdio: 'ignore'
+  })
+
+  const i18nFixtureRoot = path.join(testRoot, 'i18n')
+  const i18nExampleDirectory = path.join(i18nFixtureRoot, 'example')
+  const frenchDirectory = path.join(i18nFixtureRoot, 'fr')
+  const germanDirectory = path.join(i18nFixtureRoot, 'de')
+  const spanishDirectory = path.join(i18nFixtureRoot, 'es')
+  fs.mkdirSync(i18nExampleDirectory, { recursive: true })
+  fs.mkdirSync(frenchDirectory)
+  fs.mkdirSync(germanDirectory)
+  fs.mkdirSync(spanishDirectory)
+  fs.copyFileSync(
+    path.resolve(__dirname, '../../i18n/check.js'),
+    path.join(i18nFixtureRoot, 'check.js')
+  )
+  const exampleTranslations = {
+    hello: 'Hello {name}',
+    bye: 'Bye'
+  }
+  fs.writeFileSync(
+    path.join(i18nExampleDirectory, 'translations.json'),
+    JSON.stringify(exampleTranslations)
+  )
+  fs.writeFileSync(
+    path.join(frenchDirectory, 'translations.json'),
+    JSON.stringify({ hello: 'Bonjour {name}', old: 'Old' })
+  )
+  execFileSync(process.execPath, [
+    path.join(i18nFixtureRoot, 'check.js'),
+    '--overwrite',
+    'fr'
+  ], { stdio: 'ignore' })
+  assert.deepStrictEqual(
+    JSON.parse(fs.readFileSync(path.join(frenchDirectory, 'translations.json'), 'utf-8')),
+    { hello: 'Bonjour {name}', bye: 'Bye' }
+  )
+  execFileSync(process.execPath, [
+    path.join(i18nFixtureRoot, 'check.js'),
+    '--overwrite',
+    'de'
+  ], { stdio: 'ignore' })
+  assert.deepStrictEqual(
+    JSON.parse(fs.readFileSync(path.join(germanDirectory, 'translations.json'), 'utf-8')),
+    exampleTranslations
+  )
+  if (process.platform !== 'win32') {
+    assert.strictEqual(
+      fs.statSync(path.join(germanDirectory, 'translations.json')).mode & 0o777,
+      0o600
+    )
+    const outsideTranslations = path.join(testRoot, 'outside-translations.json')
+    fs.writeFileSync(outsideTranslations, JSON.stringify({ hello: 'Outside' }))
+    fs.symlinkSync(
+      outsideTranslations,
+      path.join(spanishDirectory, 'translations.json')
+    )
+    const symlinkCheck = spawnSync(process.execPath, [
+      path.join(i18nFixtureRoot, 'check.js'),
+      '--overwrite',
+      'es'
+    ], { encoding: 'utf-8' })
+    assert.notStrictEqual(symlinkCheck.status, 0)
+    assert.deepStrictEqual(
+      JSON.parse(fs.readFileSync(outsideTranslations, 'utf-8')),
+      { hello: 'Outside' }
+    )
+  }
+
+  for (const signScript of [
+    '../../build-scripts/macos/app/sign.sh',
+    '../../build-scripts/macos/pkg/sign.sh'
+  ]) {
+    const signScriptContents = fs.readFileSync(
+      path.resolve(__dirname, signScript),
+      'utf-8'
+    )
+    assert.match(signScriptContents, /mktemp -d/)
+    assert.match(signScriptContents, /trap cleanup_entitlements 0/)
+    assert.doesNotMatch(signScriptContents, /electron-build-mas\/entitlements/)
+  }
+
+  console.log('[codeql-hardening] Regression tests passed.')
+} finally {
+  fs.rmSync(testRoot, { recursive: true, force: true })
+}

--- a/test/fixtures/min-versions.json
+++ b/test/fixtures/min-versions.json
@@ -1,0 +1,7 @@
+{
+  "min": {
+    "stable": "0.1.0",
+    "nightly": "0.1.0-nightly-202205301917",
+    "internal": "0.1.0-internal-202205301821"
+  }
+}

--- a/test/playwright/downloadLatestReleases.spec.js
+++ b/test/playwright/downloadLatestReleases.spec.js
@@ -4,6 +4,7 @@ const { chromium } = require('playwright')
 const path = require('path')
 const ScreenshotsPath = 'test/output/playwright/downloadLatest/'
 const app = require('../../developer/app.js')
+const escapeRegExp = require('../utils/escapeRegExp')
 let browser, page
 test.beforeAll(async () => {
   browser = await chromium.launch({
@@ -65,7 +66,7 @@ test.describe(`download stable version ${app.name}`, () => {
     process.platform === 'darwin' ? fileExt = 'dmg'
       : process.platform === 'win32' ? fileExt = 'msi'
         : fileExt = 'deb'
-    const regex = new RegExp(`^${app.name.toLowerCase()}-${tagName}\.${fileExt}$`)
+    const regex = new RegExp(`^${escapeRegExp(app.name.toLowerCase())}-${escapeRegExp(tagName)}\\.${escapeRegExp(fileExt)}$`)
     expect(regex.test(fileSuggestedFilename)).toBe(true)
 
     const targetPath = path.resolve(__dirname, `../../${app.name.toLowerCase()}.${fileExt}`)

--- a/test/utils/escapeRegExp.js
+++ b/test/utils/escapeRegExp.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = value => String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/test/utils/modifyVersion.js
+++ b/test/utils/modifyVersion.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const fetch = require('node-fetch')
+const minVersionsFixture = require('../fixtures/min-versions.json')
 
 const modifyVersion = async (opt = {}) => new Promise(resolve => {
   if (!opt) resolve(false)
@@ -20,22 +20,7 @@ const modifyVersion = async (opt = {}) => new Promise(resolve => {
 })
 
 const getminversions = async () => {
-  const app = require('../../developer/app')
-  const versionsUrl = app.versionsUrl
-  console.log(versionsUrl)
-  let versions
-  try {
-    versions = await (await fetch(versionsUrl)).json()
-  } catch (e) {
-    versions = {
-      min: {
-        stable: '0.1.0',
-        nightly: '0.1.0-nightly-202205301917',
-        internal: '0.1.0-internal-202205301821'
-      }
-    }
-  }
-  return versions.min
+  return { ...minVersionsFixture.min }
 }
 
 const getUpdatableVersion = (channel, minVersion, opt = { isExpired: false }) => {


### PR DESCRIPTION
## Summary

- makes macOS entitlement generation use a caller-created private directory, exclusive 0600 writes, deterministic cleanup, and fail-closed error propagation
- replaces dynamic build command construction with validated argument boundaries on Unix and Windows
- hardens Electron packaging, i18n writes, and WebTorrent persistence against symlink, traversal, overwrite, and file-race conditions
- replaces the live-network minimum-version test with a deterministic fixture and fixes dynamic release-name regex escaping
- runs the new security regression suite on Ubuntu and Windows, and keeps the actual packaged WebTorrent artifacts byte-identical to the reviewed public sources

## CodeQL scope

This patch is intended to remediate the current direct findings #3592, #3591, #3589, #3588, #3587, #3586, #3585, #3584, and #1910. It does not suppress or dismiss alerts. Finding #3590 and broader generated or bundled dependency debt remain separate triage items.

## Verification completed locally

- JavaScript and shell syntax checks
- GitHub Actions YAML parse
- yarn security:test-codeql
- yarn security:scan
- yarn security:test-scan
- yarn security:test-appx
- yarn security:test-appx:forge
- Jest release-test discovery
- staged and working-tree diff checks
- independent read-only security review

## Merge gates

Do not merge unless the full required CI matrix passes on GitHub, including real Windows execution and security-extended CodeQL. Confirm the PR alert delta rather than treating a green workflow alone as proof.

No release assets, signing credentials, alert dismissals, or direct main changes are included.