### PR TITLE
security: reject unsafe shell quote operators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
           yarn security:test-appx
           yarn security:test-codeql
           yarn security:test-crypto-transitives
+          yarn security:test-shell-quote
 
   windows-appx-boundary:
     name: Windows APPX signing boundary
@@ -164,6 +165,10 @@ jobs:
       - name: Verify crypto transitive boundaries
         shell: pwsh
         run: yarn security:test-crypto-transitives
+
+      - name: Verify shell quoting boundary
+        shell: pwsh
+        run: yarn security:test-shell-quote
 
       - name: Verify the Forge APPX maker boundary
         shell: pwsh

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "security:test-appx": "node scripts/security/test-appx-signing.js",
     "security:test-appx:forge": "node scripts/security/test-appx-signing.js --forge-config",
     "security:test-codeql": "node scripts/security/test-codeql-hardening.js",
-    "security:test-crypto-transitives": "node scripts/security/test-crypto-transitives.js"
+    "security:test-crypto-transitives": "node scripts/security/test-crypto-transitives.js",
+    "security:test-shell-quote": "node scripts/security/test-shell-quote.js"
   },
   "dependencies": {
     "big-json": "^3.2.0",
@@ -135,6 +136,7 @@
     "fs-chunk-store": "2.0.4",
     "pbkdf2": "3.1.3",
     "sha.js": "2.4.12",
+    "shell-quote": "1.8.4",
     "utf-8-validate": "5.0.8"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "fs-chunk-store": "2.0.4",
     "pbkdf2": "3.1.3",
     "sha.js": "2.4.12",
-    "shell-quote": "1.8.4",
+    "shell-quote": "1.9.0",
     "utf-8-validate": "5.0.8"
   },
   "config": {

--- a/scripts/security/test-shell-quote.js
+++ b/scripts/security/test-shell-quote.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const assert = require('assert').strict
+const { parse, quote } = require('shell-quote')
+
+assert.equal(require('shell-quote/package.json').version, '1.8.4')
+
+const safeArguments = [
+  'echo',
+  'AlphaBiz shell quote regression',
+  'literal;$HOME',
+  'line-without-terminator'
+]
+assert.deepEqual(parse(quote(safeArguments)), safeArguments)
+
+const validOperators = [
+  '||', '&&', ';;', '|&', '<(', '<<<', '>>', '>&', '<&',
+  '&', ';', '(', ')', '|', '<', '>'
+]
+for (const op of validOperators) {
+  assert.doesNotThrow(() => quote([{ op }]))
+}
+
+const lineTerminators = ['\n', '\r', '\u2028', '\u2029']
+const invalidOperators = lineTerminators
+  .map((terminator) => `;${terminator}id`)
+  .concat(['$(id)', 'unknown'])
+for (const op of invalidOperators) {
+  assert.throws(
+    () => quote([{ op }]),
+    TypeError,
+    `shell-quote accepted an unsafe operator: ${JSON.stringify(op)}`
+  )
+}
+
+assert.throws(() => quote([{ op: 1 }]), TypeError)
+assert.throws(() => quote([{ unknown: 'shape' }]), TypeError)
+
+const envTokens = parse('echo $X', () => ({ op: ';\nid' }))
+assert.throws(
+  () => quote(envTokens),
+  TypeError,
+  'shell-quote accepted an unsafe operator returned by envFn'
+)
+
+const globOutput = quote([{ op: 'glob', pattern: '*.js' }])
+assert.equal(globOutput, '*.js')
+
+for (const terminator of lineTerminators) {
+  assert.throws(
+    () => quote([{ comment: `safe${terminator}second-command` }]),
+    TypeError
+  )
+  assert.throws(
+    () => quote([{ op: 'glob', pattern: `*.js${terminator}second-command` }]),
+    TypeError
+  )
+}
+
+console.log('[shell-quote] Operator, comment, glob, and envFn injection boundaries passed.')

--- a/scripts/security/test-shell-quote.js
+++ b/scripts/security/test-shell-quote.js
@@ -3,7 +3,7 @@
 const assert = require('assert').strict
 const { parse, quote } = require('shell-quote')
 
-assert.equal(require('shell-quote/package.json').version, '1.8.4')
+assert.equal(require('shell-quote/package.json').version, '1.9.0')
 
 const safeArguments = [
   'echo',
@@ -56,5 +56,26 @@ for (const terminator of lineTerminators) {
     TypeError
   )
 }
+
+const originalConcat = Array.prototype.concat
+let concatSourceItems = 0
+let manyTokens
+let expandedEnvTokens
+Array.prototype.concat = function (...items) {
+  concatSourceItems += this.length
+  return originalConcat.apply(this, items)
+}
+
+try {
+  manyTokens = parse('x '.repeat(4096))
+  expandedEnvTokens = parse('$X '.repeat(256), () => ['a', 'b'])
+} finally {
+  Array.prototype.concat = originalConcat
+}
+
+assert.equal(manyTokens.length, 4096)
+assert.equal(expandedEnvTokens.length, 256)
+assert.deepEqual(expandedEnvTokens[0], ['a', 'b'])
+assert.equal(concatSourceItems, 0, 'shell-quote parse() still copies a growing concat accumulator')
 
 console.log('[shell-quote] Operator, comment, glob, and envFn injection boundaries passed.')

--- a/yarn.lock
+++ b/yarn.lock
@@ -13248,10 +13248,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@^1.4.3, shell-quote@^1.7.2:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
-  integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
+shell-quote@1.8.4, shell-quote@^1.4.3, shell-quote@^1.7.2:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
+  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
 
 shelljs@^0.8.4:
   version "0.8.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13248,10 +13248,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-quote@1.8.4, shell-quote@^1.4.3, shell-quote@^1.7.2:
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
-  integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
+shell-quote@1.9.0, shell-quote@^1.4.3, shell-quote@^1.7.2:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.9.0.tgz#e108b1a136586d5964edb3300016d4bedba0fe57"
+  integrity sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==
 
 shelljs@^0.8.4:
   version "0.8.5"


### PR DESCRIPTION
## Summary

- pin transitive `shell-quote` to 1.9.0 through the existing Yarn Classic `resolutions` boundary
- add a regression for direct object-token and `envFn` command-injection shapes without executing a shell
- enforce the gate on both Linux and Windows CI

## Security impact

This targets open critical Dependabot alert #311 (`GHSA-w7jw-789q-3m8p`) and high alert #337 (`GHSA-395f-4hp3-45gv`). The previous `shell-quote` 1.7.3 preserved a literal line terminator in attacker-shaped `{ op }` input. Version 1.9.0 includes the strict object-token validation introduced in 1.8.4 and is the first release that also replaces the quadratic `parse()` accumulator.

The regression covers LF, CR, U+2028, and U+2029 across operator, comment, and glob tokens; direct construction; `envFn` return values; invalid/non-string operators; unknown object shapes; the full valid operator allowlist; and a deterministic accumulator-copy check for both normal and `envFn` parsing. It never invokes `child_process` or passes output to a shell.

## Verification

- Node 22.23.2 + Yarn 1.22.22 clean frozen install from an empty `node_modules`, with lifecycle scripts and optional packages disabled
- new regression passed on Node 22.23.2 and Node 25.9.0
- existing credential-scan, APPX-signing, CodeQL-hardening, and crypto-transitive regressions passed
- credential scan: 889 tracked files
- Jest release-test discovery passed
- lockfile semantic delta is only `shell-quote` 1.7.3 → 1.9.0
- target SHA-512 matched public npm registry metadata
- independent diff/regression review: PASS

No application source, release artifact, signing material, or generated bundle is changed. Rollback is a normal revert of the merge commit.
