### PR TITLE
fix(deps): remove vulnerable minimist chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
           yarn security:test-crypto-transitives
           yarn security:test-shell-quote
           yarn security:test-babel-traverse
+          yarn security:test-minimist
 
   windows-appx-boundary:
     name: Windows APPX signing boundary
@@ -174,6 +175,10 @@ jobs:
       - name: Verify Babel traversal boundary
         shell: pwsh
         run: yarn security:test-babel-traverse
+
+      - name: Verify minimist prototype boundary
+        shell: pwsh
+        run: yarn security:test-minimist
 
       - name: Verify the Forge APPX maker boundary
         shell: pwsh

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "security:test-codeql": "node scripts/security/test-codeql-hardening.js",
     "security:test-crypto-transitives": "node scripts/security/test-crypto-transitives.js",
     "security:test-shell-quote": "node scripts/security/test-shell-quote.js",
-    "security:test-babel-traverse": "node scripts/security/test-babel-traverse.js"
+    "security:test-babel-traverse": "node scripts/security/test-babel-traverse.js",
+    "security:test-minimist": "node scripts/security/test-minimist-hardening.js"
   },
   "dependencies": {
     "big-json": "^3.2.0",
@@ -129,6 +130,7 @@
   },
   "resolutions": {
     "@babel/traverse": "7.23.2",
+    "appium/appium-tizen-driver/jimp/@jimp/custom/@jimp/core/mkdirp": "0.5.6",
     "bittorrent-protocol": "3.5.1",
     "bufferutil": "4.0.6",
     "cipher-base": "1.0.6",

--- a/scripts/security/test-minimist-hardening.js
+++ b/scripts/security/test-minimist-hardening.js
@@ -18,7 +18,7 @@ assert.equal(
   'The vulnerable minimist 0.0.8 selector remains in the frozen lockfile'
 )
 assert.ok(
-  /mkdirp@0\.5\.1, mkdirp@0\.5\.6:\n  version "0\.5\.6"/.test(lockfile),
+  /mkdirp@0\.5\.1, mkdirp@0\.5\.6:\r?\n  version "0\.5\.6"/.test(lockfile),
   'The exact Appium/Tizen mkdirp override is missing from the frozen lockfile'
 )
 

--- a/scripts/security/test-minimist-hardening.js
+++ b/scripts/security/test-minimist-hardening.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const assert = require('assert').strict
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const repositoryRoot = path.resolve(__dirname, '..', '..')
+const packageManifest = require(path.join(repositoryRoot, 'package.json'))
+const lockfile = fs.readFileSync(path.join(repositoryRoot, 'yarn.lock'), 'utf8')
+const resolutionPath = 'appium/appium-tizen-driver/jimp/@jimp/custom/@jimp/core/mkdirp'
+
+assert.equal(packageManifest.resolutions[resolutionPath], '0.5.6')
+assert.equal(
+  /^minimist@0\.0\.8:/m.test(lockfile),
+  false,
+  'The vulnerable minimist 0.0.8 selector remains in the frozen lockfile'
+)
+assert.ok(
+  /mkdirp@0\.5\.1, mkdirp@0\.5\.6:\n  version "0\.5\.6"/.test(lockfile),
+  'The exact Appium/Tizen mkdirp override is missing from the frozen lockfile'
+)
+
+function resolvePackage (name, searchPath) {
+  const manifestPath = require.resolve(`${name}/package.json`, { paths: [searchPath] })
+  return {
+    directory: path.dirname(manifestPath),
+    manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+    modulePath: require.resolve(name, { paths: [searchPath] })
+  }
+}
+
+const appium = resolvePackage('appium', repositoryRoot)
+const tizenDriver = resolvePackage('appium-tizen-driver', appium.directory)
+const jimp = resolvePackage('jimp', tizenDriver.directory)
+const jimpCustom = resolvePackage('@jimp/custom', jimp.directory)
+const jimpCore = resolvePackage('@jimp/core', jimpCustom.directory)
+const targetMkdirp = resolvePackage('mkdirp', jimpCore.directory)
+const targetMinimist = resolvePackage('minimist', targetMkdirp.directory)
+
+assert.equal(jimp.manifest.version, '0.5.6')
+assert.equal(jimpCore.manifest.version, '0.5.4')
+assert.equal(targetMkdirp.manifest.version, '0.5.6')
+assert.equal(targetMinimist.manifest.version, '1.2.6')
+
+const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alphabiz-mkdirp-'))
+const nestedDirectory = path.join(temporaryRoot, 'nested', 'directory')
+
+try {
+  require(targetMkdirp.modulePath).sync(nestedDirectory)
+  assert.equal(fs.statSync(nestedDirectory).isDirectory(), true)
+} finally {
+  fs.rmSync(temporaryRoot, { recursive: true, force: true })
+}
+
+function assertIsolatedProbe (source, boundary) {
+  const pollutionProbe = spawnSync(process.execPath, [
+    '-e',
+    source.join('\n'),
+    targetMinimist.modulePath
+  ], {
+    encoding: 'utf8',
+    timeout: 5000
+  })
+
+  assert.equal(pollutionProbe.error, undefined)
+  assert.equal(
+    pollutionProbe.status,
+    0,
+    `minimist crossed the ${boundary} prototype boundary: ${pollutionProbe.stderr}`
+  )
+}
+
+assertIsolatedProbe([
+  'const parse = require(process.argv[1])',
+  "parse(['--_.constructor.constructor.prototype.alphabizMinimistProbe', 'safe'])",
+  'if ((function () {}).alphabizMinimistProbe !== undefined) process.exit(23)'
+], 'constructor')
+
+assertIsolatedProbe([
+  'const parse = require(process.argv[1])',
+  "parse(['--__proto__.alphabizMinimistObjectProbe=unsafe'])",
+  'if (({}).alphabizMinimistObjectProbe !== undefined) process.exit(24)'
+], 'object')
+
+console.log('[minimist] Targeted Appium/Tizen chain and prototype-pollution boundary passed.')

--- a/yarn.lock
+++ b/yarn.lock
@@ -10779,11 +10779,6 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
@@ -10895,12 +10890,12 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+mkdirp@0.5.1, mkdirp@0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
-    minimist "0.0.8"
+    minimist "^1.2.6"
 
 mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"


### PR DESCRIPTION
## Summary

- replace the exact Appium/Tizen → Jimp legacy `mkdirp@0.5.1` edge with the same-series `mkdirp@0.5.6` security patch
- remove the resulting `minimist@0.0.8` lock entry and reuse the already locked patched `minimist@1.2.6`
- add isolated constructor and `__proto__` prototype-pollution regressions
- run the new gate on both protected Node 22 CI jobs

## Security impact

The removed `minimist@0.0.8` entry is affected by CVE-2021-44906 / GHSA-xvch-5gv4-984h and CVE-2020-7598 / GHSA-vh95-rmgr-6w4m. The resolution is scoped to the only exact `mkdirp@0.5.1` request in the graph:

`appium → appium-tizen-driver → jimp → @jimp/custom → @jimp/core → mkdirp`

This is narrower and more compatible than forcing every historical `minimist` consumer across a major-version boundary. The expected Yarn compatibility warning records the exact `mkdirp 0.5.1 → 0.5.6` override.

The probes run in disposable child processes without a shell. Cached pre-fix `minimist@0.0.8` exits 23/24 for the constructor and object-prototype vectors; patched `1.2.6` exits 0 for both.

This change is intended to resolve Dependabot alerts #100 and #1. Dependency Review remains a required merge gate.

## Verification

- clean Yarn Classic frozen install under Node 22 with lifecycle scripts, optional packages, and binary downloads disabled
- all credential and security regression suites passed
- release Jest test discovery passed
- new regression passed under Node 22 and Node 25
- target Appium/Tizen driver require, nested Jimp PNG write, and `mkdirp.sync` compatibility passed
- `mkdirp@0.5.6` integrity matches npm metadata and has no install lifecycle script
- independent security review: PASS, no required corrections
