### PR TITLE
fix(security): harden form-data multipart boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
           yarn security:test-shell-quote
           yarn security:test-babel-traverse
           yarn security:test-minimist
+          yarn security:test-form-data
 
   windows-appx-boundary:
     name: Windows APPX signing boundary
@@ -179,6 +180,10 @@ jobs:
       - name: Verify minimist prototype boundary
         shell: pwsh
         run: yarn security:test-minimist
+
+      - name: Verify form-data boundary entropy
+        shell: pwsh
+        run: yarn security:test-form-data
 
       - name: Verify the Forge APPX maker boundary
         shell: pwsh

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "security:test-crypto-transitives": "node scripts/security/test-crypto-transitives.js",
     "security:test-shell-quote": "node scripts/security/test-shell-quote.js",
     "security:test-babel-traverse": "node scripts/security/test-babel-traverse.js",
-    "security:test-minimist": "node scripts/security/test-minimist-hardening.js"
+    "security:test-minimist": "node scripts/security/test-minimist-hardening.js",
+    "security:test-form-data": "node scripts/security/test-form-data-boundary.js"
   },
   "dependencies": {
     "big-json": "^3.2.0",
@@ -130,6 +131,9 @@
   },
   "resolutions": {
     "@babel/traverse": "7.23.2",
+    "**/appium-support/form-data": "4.0.6",
+    "**/jsdom/form-data": "3.0.5",
+    "**/request/form-data": "2.5.6",
     "appium/appium-tizen-driver/jimp/@jimp/custom/@jimp/core/mkdirp": "0.5.6",
     "bittorrent-protocol": "3.5.1",
     "bufferutil": "4.0.6",

--- a/scripts/security/test-form-data-boundary.js
+++ b/scripts/security/test-form-data-boundary.js
@@ -1,0 +1,163 @@
+'use strict'
+
+const assert = require('assert').strict
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const repositoryRoot = path.resolve(__dirname, '..', '..')
+const packageManifest = require(path.join(repositoryRoot, 'package.json'))
+const lockfile = fs.readFileSync(path.join(repositoryRoot, 'yarn.lock'), 'utf8')
+  .replace(/\r\n/g, '\n')
+
+const expectedResolutions = {
+  '**/appium-support/form-data': '4.0.6',
+  '**/jsdom/form-data': '3.0.5',
+  '**/request/form-data': '2.5.6'
+}
+
+for (const [selector, version] of Object.entries(expectedResolutions)) {
+  assert.equal(packageManifest.resolutions[selector], version)
+}
+
+function assertLockedVersion (selector, version) {
+  const start = lockfile.indexOf(selector)
+  assert.notEqual(start, -1, `Missing frozen form-data selector: ${selector}`)
+
+  const end = lockfile.indexOf('\n\n', start)
+  const block = lockfile.slice(start, end === -1 ? lockfile.length : end)
+  assert.ok(
+    block.includes(`\n  version "${version}"`),
+    `${selector} is not frozen to form-data ${version}`
+  )
+}
+
+assertLockedVersion(
+  'form-data@2.5.6, form-data@^2.5.0, form-data@~2.3.2:',
+  '2.5.6'
+)
+assertLockedVersion('form-data@3.0.5, form-data@^3.0.0:', '3.0.5')
+assertLockedVersion('form-data@4.0.6, form-data@^4.0.0:', '4.0.6')
+
+const formDataBlocks = lockfile.split('\n\n')
+  .filter((block) => block.startsWith('form-data@'))
+
+for (const vulnerableVersion of [
+  '2.3.3',
+  '2.5.1',
+  '2.5.5',
+  '3.0.1',
+  '3.0.4',
+  '4.0.0',
+  '4.0.4'
+]) {
+  assert.equal(
+    formDataBlocks.some((block) => block.includes(`\n  version "${vulnerableVersion}"`)),
+    false,
+    `Vulnerable form-data ${vulnerableVersion} remains in the frozen lockfile`
+  )
+}
+
+function resolvePackage (name, searchPath) {
+  const manifestPath = require.resolve(`${name}/package.json`, { paths: [searchPath] })
+  return {
+    directory: path.dirname(manifestPath),
+    manifestPath,
+    manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+    modulePath: require.resolve(name, { paths: [searchPath] })
+  }
+}
+
+const appium = resolvePackage('appium', repositoryRoot)
+const appiumSupport = resolvePackage('appium-support', appium.directory)
+const jsdom = resolvePackage('jsdom', repositoryRoot)
+const requestTypesManifest = require.resolve('@types/request/package.json', {
+  paths: [repositoryRoot]
+})
+const requestConsumers = [
+  resolvePackage('@cypress/request', repositoryRoot),
+  resolvePackage('request', repositoryRoot),
+  { directory: path.dirname(requestTypesManifest) }
+]
+
+for (const consumer of requestConsumers) {
+  assert.equal(resolvePackage('form-data', consumer.directory).manifest.version, '2.5.6')
+}
+
+const installations = [
+  {
+    label: 'request-compatible 2.x graph',
+    expectedVersion: '2.5.6',
+    package: resolvePackage('form-data', repositoryRoot)
+  },
+  {
+    label: 'jsdom 3.x graph',
+    expectedVersion: '3.0.5',
+    package: resolvePackage('form-data', jsdom.directory)
+  },
+  {
+    label: 'appium-support 4.x graph',
+    expectedVersion: '4.0.6',
+    package: resolvePackage('form-data', appiumSupport.directory)
+  }
+]
+
+const probeSource = [
+  "'use strict'",
+  "const assert = require('assert').strict",
+  'const FormData = require(process.argv[1])',
+  'const manifest = require(process.argv[2])',
+  'const expectedVersion = process.argv[3]',
+  'assert.equal(manifest.version, expectedVersion)',
+  'const originalRandom = Math.random',
+  "Math.random = () => { throw new Error('form-data consulted Math.random') }",
+  'let boundary',
+  'let form',
+  'try {',
+  '  form = new FormData()',
+  '  boundary = form.getBoundary()',
+  '} finally {',
+  '  Math.random = originalRandom',
+  '}',
+  "assert.match(boundary, /^--------------------------[0-9a-f]{24}$/)",
+  "form.append('field', 'value')",
+  "form.append('file', Buffer.from('abc'), { filename: 'sample.txt', contentType: 'text/plain', knownLength: 3 })",
+  'const headers = form.getHeaders()',
+  "assert.equal(headers['content-type'], `multipart/form-data; boundary=${boundary}`)",
+  'const body = form.getBuffer()',
+  "assert.ok(body.includes(Buffer.from('value')))",
+  "assert.ok(body.includes(Buffer.from('abc')))",
+  'assert.equal(form.getLengthSync(), body.length)',
+  'const escaped = new FormData()',
+  "escaped.append('field\\\"\\r\\nline', 'safe')",
+  "escaped.append('file', Buffer.from('abc'), { filename: 'sample\\\"\\r\\nfile.txt' })",
+  "const escapedBody = escaped.getBuffer().toString('latin1')",
+  "assert.ok(escapedBody.includes('name=\\\"field%22%0D%0Aline\\\"'))",
+  "assert.ok(escapedBody.includes('filename=\\\"sample%22%0D%0Afile.txt\\\"'))",
+  "assert.equal(escapedBody.includes('field\\\"\\r\\nline'), false)",
+  "assert.equal(escapedBody.includes('sample\\\"\\r\\nfile.txt'), false)"
+].join('\n')
+
+for (const installation of installations) {
+  assert.equal(installation.package.manifest.version, installation.expectedVersion)
+
+  const probe = spawnSync(process.execPath, [
+    '-e',
+    probeSource,
+    installation.package.modulePath,
+    installation.package.manifestPath,
+    installation.expectedVersion
+  ], {
+    encoding: 'utf8',
+    timeout: 5000
+  })
+
+  assert.equal(probe.error, undefined)
+  assert.equal(
+    probe.status,
+    0,
+    `${installation.label} failed its entropy or compatibility boundary: ${probe.stderr}`
+  )
+}
+
+console.log('[form-data] Patched 2.x, 3.x, and 4.x graphs pass entropy, CRLF escaping, and compatibility boundaries.')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5502,7 +5502,7 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -6788,6 +6788,16 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   dependencies:
     es-errors "^1.3.0"
 
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 es6-error@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
@@ -7509,41 +7519,39 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@^2.5.0:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
-  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+form-data@2.5.6, form-data@^2.5.0, form-data@~2.3.2:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#ef39b3d99e2fc9f25420c0db7962fe36cafcd244"
+  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+    safe-buffer "^5.2.1"
 
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+form-data@3.0.5, form-data@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.5.tgz#2ea3ec24f0dcb7e0262a11efb732031240ea8e9f"
+  integrity sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+form-data@4.0.6, form-data@^4.0.0:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -7856,7 +7864,7 @@ get-intrinsic@^1.0.2:
     has "^1.0.3"
     has-symbols "^1.0.1"
 
-get-intrinsic@^1.2.4, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -8278,7 +8286,7 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hasown@^2.0.2:
+hasown@^2.0.2, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
@@ -10691,7 +10699,19 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
-mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==


### PR DESCRIPTION
## Summary

- pin the request-compatible `form-data` graph to `2.5.6`
- pin the jsdom graph to `3.0.5` and the appium-support graph to `4.0.6`
- add a cross-platform regression gate for cryptographic multipart boundaries, CRLF/quote escaping, and basic API compatibility
- run the new gate on both Linux and Windows CI

These versions close both GHSA-fjxv-7rqg-78g4 / CVE-2025-7783 and GHSA-hmw2-7cc7-3qxx / CVE-2026-12143. On the current default branch, the same three dependency paths account for six open Dependabot alerts: three critical and three high.

## Scope and compatibility

The Yarn Classic resolutions are path-scoped:

- `@cypress/request`, `request`, and `@types/request` resolve to `form-data@2.5.6`
- `jsdom` resolves to `form-data@3.0.5`
- `appium-support` resolves to `form-data@4.0.6`

The request graph intentionally overrides two legacy `~2.3.2` declarations while staying on the 2.x API. The regression gate exercises append, headers, buffer serialization, and synchronous length calculation for all three installed versions. No application source or release binary is changed.

## Verification

- clean Node 22 frozen install with lifecycle scripts and optional dependencies disabled
- complete repository security regression set
- new form-data gate on Node 22 and Node 25
- old vulnerable versions fail the entropy probe; the superseded 2.5.5/3.0.4/4.0.4 set fails the CRLF probe
- release-test discovery finds the expected Jest suite
- Yarn integrity check passes
- credential scan passes across 892 tracked files
- all six newly added package integrities match npm registry metadata
- independent review: PASS

## Rollback

Revert commit `a05b9e8d83e74149763935a8892eb2c8f1e8aa7b`.
