### PR TITLE
fix(security): harden brace expansion graphs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
           yarn security:test-babel-traverse
           yarn security:test-minimist
           yarn security:test-form-data
+          yarn security:test-brace-expansion
 
   windows-appx-boundary:
     name: Windows APPX signing boundary
@@ -184,6 +185,10 @@ jobs:
       - name: Verify form-data boundary entropy
         shell: pwsh
         run: yarn security:test-form-data
+
+      - name: Verify brace-expansion resource bounds
+        shell: pwsh
+        run: yarn security:test-brace-expansion
 
       - name: Verify the Forge APPX maker boundary
         shell: pwsh

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "security:test-shell-quote": "node scripts/security/test-shell-quote.js",
     "security:test-babel-traverse": "node scripts/security/test-babel-traverse.js",
     "security:test-minimist": "node scripts/security/test-minimist-hardening.js",
-    "security:test-form-data": "node scripts/security/test-form-data-boundary.js"
+    "security:test-form-data": "node scripts/security/test-form-data-boundary.js",
+    "security:test-brace-expansion": "node scripts/security/test-brace-expansion.js"
   },
   "dependencies": {
     "big-json": "^3.2.0",

--- a/scripts/security/test-brace-expansion.js
+++ b/scripts/security/test-brace-expansion.js
@@ -1,0 +1,169 @@
+'use strict'
+
+const assert = require('assert').strict
+const fs = require('fs')
+const path = require('path')
+const { spawnSync } = require('child_process')
+
+const repositoryRoot = path.resolve(__dirname, '..', '..')
+const lockfile = fs.readFileSync(path.join(repositoryRoot, 'yarn.lock'), 'utf8')
+  .replace(/\r\n/g, '\n')
+const braceBlocks = lockfile.split('\n\n')
+  .filter((block) => /^"?brace-expansion@/.test(block))
+
+assert.equal(braceBlocks.length, 2, 'Unexpected brace-expansion selector entered the lockfile')
+
+function assertLockedVersion (selector, version) {
+  const block = braceBlocks.find((candidate) => {
+    const header = candidate.split('\n', 1)[0]
+    return header === selector || header === `"${selector.slice(0, -1)}":`
+  })
+  assert.ok(block, `Missing frozen brace-expansion selector: ${selector}`)
+  assert.ok(
+    block.includes(`\n  version "${version}"`),
+    `${selector} is not frozen to brace-expansion ${version}`
+  )
+}
+
+assertLockedVersion('brace-expansion@^1.1.7:', '1.1.18')
+assertLockedVersion('brace-expansion@^2.0.1:', '2.1.4')
+
+const lockedVersions = braceBlocks.map((block) => {
+  const match = block.match(/\n  version "([^"]+)"/)
+  assert.ok(match, 'brace-expansion lock block has no version')
+  return match[1]
+}).sort()
+
+assert.deepEqual(lockedVersions, ['1.1.18', '2.1.4'])
+
+function resolvePackage (name, searchPath) {
+  const manifestPath = require.resolve(`${name}/package.json`, { paths: [searchPath] })
+  return {
+    directory: path.dirname(manifestPath),
+    manifestPath,
+    manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+    modulePath: require.resolve(name, { paths: [searchPath] })
+  }
+}
+
+const rootMinimatch = resolvePackage('minimatch', repositoryRoot)
+const playwright = resolvePackage('@playwright/test', repositoryRoot)
+const playwrightMinimatch = resolvePackage('minimatch', playwright.directory)
+const electronRebuild = resolvePackage('@electron/rebuild', repositoryRoot)
+const electronMinimatch = resolvePackage('minimatch', electronRebuild.directory)
+
+const installations = [
+  {
+    label: 'minimatch 3.x runtime graph',
+    expectedVersion: '1.1.18',
+    package: resolvePackage('brace-expansion', rootMinimatch.directory)
+  },
+  {
+    label: 'Playwright minimatch 3.x graph',
+    expectedVersion: '1.1.18',
+    package: resolvePackage('brace-expansion', playwrightMinimatch.directory)
+  },
+  {
+    label: 'electron-rebuild minimatch 5.x graph',
+    expectedVersion: '2.1.4',
+    package: resolvePackage('brace-expansion', electronMinimatch.directory)
+  }
+]
+
+const probeSource = [
+  "'use strict'",
+  "const assert = require('assert').strict",
+  'const expand = require(process.argv[1])',
+  'const manifest = require(process.argv[2])',
+  'const expectedVersion = process.argv[3]',
+  'const NativeString = String',
+  'function countStringCalls (run) {',
+  '  let calls = 0',
+  '  function CountingString (value) {',
+  '    calls += 1',
+  '    return NativeString(value)',
+  '  }',
+  '  Object.setPrototypeOf(CountingString, NativeString)',
+  '  CountingString.prototype = NativeString.prototype',
+  '  const previous = global.String',
+  '  global.String = CountingString',
+  '  try {',
+  '    return { output: run(), calls }',
+  '  } finally {',
+  '    global.String = previous',
+  '  }',
+  '}',
+  'function totalLength (values) {',
+  '  return values.reduce((total, value) => total + value.length, 0)',
+  '}',
+  'assert.equal(manifest.version, expectedVersion)',
+  "assert.deepEqual(expand('a{b,c}d'), ['abd', 'acd'])",
+  "assert.deepEqual(expand('file{1..3}.txt'), ['file1.txt', 'file2.txt', 'file3.txt'])",
+  "assert.deepEqual(expand('{1..3..0}'), ['1', '2', '3'])",
+  "const nonExpanding = 'a' + Array(24).fill('{}').join(',')",
+  'assert.deepEqual(expand(nonExpanding, { max: 100, maxLength: 4096 }), [nonExpanding])',
+  'const boundedCases = [',
+  "  ['{a,b}{c,d}{e,f}', 10],",
+  "  ['{a,b,c,d,e,f,g,h}', 4],",
+  "  ['{0001..0010}', 12]",
+  ']',
+  'for (const [input, maxLength] of boundedCases) {',
+  '  const output = expand(input, { max: 100, maxLength })',
+  '  const totalLength = output.reduce((total, value) => total + value.length, 0)',
+  '  assert.ok(output.length > 0)',
+  '  assert.ok(totalLength <= maxLength, `${input} exceeded maxLength`)',
+  '}',
+  "const sequence = '{0000000001..2}'",
+  'function alternativesProbe (count) {',
+  '  return countStringCalls(() => expand(',
+  "    '{' + Array(count).fill(sequence).join(',') + '}',",
+  '    { max: 1000, maxLength: 64 }',
+  '  ))',
+  '}',
+  'const tenAlternatives = alternativesProbe(10)',
+  'const hundredAlternatives = alternativesProbe(100)',
+  'assert.ok(totalLength(tenAlternatives.output) <= 64)',
+  'assert.ok(totalLength(hundredAlternatives.output) <= 64)',
+  'assert.deepEqual(hundredAlternatives.output, tenAlternatives.output)',
+  'assert.ok(tenAlternatives.calls <= 10)',
+  'assert.ok(hundredAlternatives.calls <= tenAlternatives.calls + 2)',
+  "const paddedSequence = '{' + '0'.repeat(63) + '1..1000}'",
+  'const paddedProbe = countStringCalls(() => expand(',
+  '  paddedSequence,',
+  '  { max: 1000, maxLength: 128 }',
+  '))',
+  'assert.equal(paddedProbe.output.length, 2)',
+  'assert.equal(totalLength(paddedProbe.output), 128)',
+  'assert.ok(paddedProbe.calls <= 4)'
+].join('\n')
+
+for (const installation of installations) {
+  assert.equal(installation.package.manifest.version, installation.expectedVersion)
+
+  const probe = spawnSync(process.execPath, [
+    '--max-old-space-size=64',
+    '-e',
+    probeSource,
+    installation.package.modulePath,
+    installation.package.manifestPath,
+    installation.expectedVersion
+  ], {
+    encoding: 'utf8',
+    timeout: 2000
+  })
+
+  assert.equal(probe.error, undefined)
+  assert.equal(
+    probe.status,
+    0,
+    `${installation.label} failed its resource or compatibility boundary: ${probe.stderr}`
+  )
+}
+
+for (const minimatchPackage of [rootMinimatch, playwrightMinimatch, electronMinimatch]) {
+  const minimatch = require(minimatchPackage.modulePath)
+  assert.equal(minimatch('src/a.js', 'src/{a,b}.js'), true)
+  assert.equal(minimatch('src/c.js', 'src/{a,b}.js'), false)
+}
+
+console.log('[brace-expansion] Patched 1.x and 2.x graphs pass bounded-expansion and minimatch compatibility checks.')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4707,17 +4707,17 @@ bplist-parser@^0.x:
     big-integer "1.6.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
## Summary

- refresh the two existing brace-expansion lockfile selectors to 1.1.18 and 2.1.4 without adding a global resolution
- add a fail-closed regression gate for the installed minimatch 3.x and 5.x dependency graphs
- exercise zero-step, exponential non-expanding-brace, output-length, and intermediate-array resource boundaries in isolated 64 MB child processes
- run the new gate on Linux and Windows CI

## Security impact

This removes the vulnerable 1.1.11 and 2.0.1 graphs and targets versions patched for all six current repository alerts:

- GHSA-3jxr-9vmj-r5cp (two alerts)
- GHSA-mh99-v99m-4gvg
- GHSA-rgw5-rvv9-x895
- GHSA-f886-m6hf-6m8v
- GHSA-v6h2-p8h4-qcjw

The immediate predecessor versions 1.1.17 and 2.1.3 were also checked as negative controls: their intermediate-array probes scale from 20 to 200 numeric conversions as alternatives increase, while 1.1.18 and 2.1.4 remain bounded at 8. Padded-sequence work falls from 1,000 conversions to 3 with identical bounded output.

## Verification

- clean Node 22 frozen install with lifecycle scripts and optional dependencies disabled
- full security regression suite on Node 22 and Node 25
- release-test discovery on Node 22 and Node 25
- Yarn integrity check
- credential scan over all 893 staged tracked files
- npm registry version, tarball hash, integrity, and dependency metadata matched to the lockfile
- independent read-only review: PASS

## Rollback

Revert commit 147d2c6891618914f794fe139532d5fd55d67ca3. The remote feature branch is intentionally retained as an audit trail.
