### PR TITLE
build: enforce 0.4.0-beta.1 version provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alphabiz",
   "main": "electron/UnPackaged/electron-main.js",
-  "version": "0.2.4",
+  "version": "0.4.0-beta.1",
   "packageManager": "yarn@1.22.22",
   "description": "Alphabiz Blockchain Cryptocurrency Application",
   "productName": "Alphabiz",
@@ -69,7 +69,10 @@
     "security:test-cross-spawn": "node scripts/security/test-cross-spawn-hardening.js",
     "security:test-picomatch": "node scripts/security/test-picomatch-hardening.js",
     "security:test-json5": "node scripts/security/test-json5-hardening.js",
-    "security:test-semver": "node scripts/security/test-semver-hardening.js"
+    "security:test-semver": "node scripts/security/test-semver-hardening.js",
+    "release:test-version": "node scripts/release/test-version-contract.js",
+    "release:validate-binary-version": "node scripts/release/validate-binary-version.js",
+    "release:validate-version": "node scripts/release/validate-version.js"
   },
   "dependencies": {
     "big-json": "^3.2.0",

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
   "targetTagName": "main",
-  "newTagName": "0.3.3"
+  "newTagName": "0.4.0-beta.1"
 }

--- a/scripts/release/test-version-contract.js
+++ b/scripts/release/test-version-contract.js
@@ -1,0 +1,153 @@
+'use strict'
+
+const assert = require('assert').strict
+const fs = require('fs')
+const path = require('path')
+const {
+  nativeVersion,
+  parseVersion,
+  releaseChannel,
+  runtimeVersion,
+  validateBuiltVersion,
+  validateReleaseMetadata,
+  validateReleaseRequest
+} = require('./version-contract')
+
+const repositoryRoot = path.resolve(__dirname, '..', '..')
+const packageJson = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'))
+const release = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 'release.json'), 'utf8'))
+
+assert.deepEqual(validateReleaseMetadata(packageJson, release), {
+  version: '0.4.0-beta.1',
+  channel: 'beta',
+  nativeVersion: '0.4.0',
+  target: 'main'
+})
+
+assert.equal(releaseChannel('0.4.0-beta.1'), 'beta')
+assert.equal(releaseChannel('0.4.0'), 'stable')
+assert.equal(nativeVersion('0.4.0-beta.1'), '0.4.0')
+
+const beta = runtimeVersion({
+  packageVersion: '0.3.3',
+  newTag: '0.4.0-beta.1',
+  buildTime: '202608300945',
+  buildCommit: '1234567',
+  sourceCommit: '1234567'
+})
+assert.deepEqual(beta, {
+  packageVer: '0.4.0-beta.1',
+  channel: 'beta',
+  buildTime: '202608300945',
+  buildCommit: '1234567',
+  sourceCommit: '1234567',
+  version: '0.4.0-beta.1'
+})
+
+const stable = runtimeVersion({
+  packageVersion: '0.3.3',
+  newTag: '0.4.0',
+  buildTime: '202608300945',
+  buildCommit: '1234567',
+  sourceCommit: '1234567'
+})
+assert.equal(stable.channel, 'stable')
+assert.equal(stable.version, '0.4.0')
+
+const stableNightly = runtimeVersion({
+  packageVersion: '0.3.3',
+  buildTime: '202608300945',
+  buildCommit: '1234567',
+  sourceCommit: '7654321'
+})
+assert.equal(stableNightly.version, '0.3.4-nightly-202608300945')
+
+const betaNightly = runtimeVersion({
+  packageVersion: '0.4.0-beta.1',
+  buildTime: '202608300945',
+  buildCommit: '1234567',
+  sourceCommit: '7654321'
+})
+assert.equal(betaNightly.version, '0.4.0-nightly-202608300945')
+
+for (const invalid of ['v0.4.0-beta.1', '0.4', '0.4.0-beta..1', '01.4.0']) {
+  assert.throws(() => parseVersion(invalid), /SemVer/)
+}
+
+assert.throws(() => runtimeVersion({
+  packageVersion: '0.3.3',
+  newTag: '0.4.0-beta.1',
+  buildTime: '2026-08-30',
+  buildCommit: '1234567',
+  sourceCommit: '1234567'
+}), /buildTime/)
+
+for (const invalidBuildTime of ['202613010000', '202602290000', '202608302460']) {
+  assert.throws(() => runtimeVersion({
+    packageVersion: '0.3.3',
+    buildTime: invalidBuildTime,
+    buildCommit: '1234567',
+    sourceCommit: '7654321'
+  }), /buildTime/)
+}
+
+assert.throws(() => validateReleaseMetadata(
+  { version: '0.4.0-beta.2' },
+  release
+), /Version mismatch/)
+
+assert.throws(() => validateReleaseRequest({
+  newTag: '0.4.0-beta.1',
+  expectedVersion: '0.4.0-beta.1',
+  sourceCommit: '1234567'
+}), /--SHA7/)
+assert.throws(() => validateReleaseRequest({
+  newTag: '0.4.0-beta.1',
+  expectedVersion: '0.4.0-beta.1',
+  buildCommit: '1234567'
+}), /--sourceSHA7/)
+assert.throws(() => validateReleaseRequest({
+  newTag: '0.4.0-beta.1',
+  expectedVersion: '0.4.0-beta.1',
+  buildCommit: '1234567',
+  sourceCommit: '1234567',
+  stable: true
+}), /prerelease/)
+assert.throws(() => validateReleaseRequest({
+  newTag: '9.9.9',
+  expectedVersion: '0.4.0-beta.1',
+  buildCommit: '1234567',
+  sourceCommit: '7654321'
+}), /declared version/)
+validateReleaseRequest({
+  newTag: '0.4.0-beta.1',
+  expectedVersion: '0.4.0-beta.1',
+  buildCommit: '1234567',
+  sourceCommit: '7654321'
+})
+
+const builtVersion = {
+  packageVer: '0.4.0-beta.1',
+  channel: 'beta',
+  buildTime: '202608300945',
+  buildCommit: '1234567',
+  sourceCommit: '7654321',
+  version: '0.4.0-beta.1'
+}
+assert.equal(validateBuiltVersion(
+  packageJson,
+  release,
+  { version: '0.4.0-beta.1' },
+  [
+    { label: 'packaged runtime', value: builtVersion },
+    { label: 'generated runtime', value: { ...builtVersion } }
+  ]
+).version, '0.4.0-beta.1')
+assert.throws(() => validateBuiltVersion(
+  packageJson,
+  release,
+  { version: '0.2.4' },
+  [{ label: 'packaged runtime', value: builtVersion }]
+), /Packaged app version mismatch/)
+
+console.log('Release version contract passed.')

--- a/scripts/release/validate-binary-version.js
+++ b/scripts/release/validate-binary-version.js
@@ -1,0 +1,27 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { validateBuiltVersion } = require('./version-contract')
+
+const repositoryRoot = path.resolve(__dirname, '..', '..')
+
+function readJson (relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repositoryRoot, relativePath), 'utf8'))
+}
+
+const packageJson = readJson('package.json')
+const release = readJson('release.json')
+const appManifest = readJson('dist/electron/UnPackaged/package.json')
+const packagedRuntime = readJson('dist/electron/UnPackaged/version.json')
+
+validateBuiltVersion(packageJson, release, appManifest, [
+  { label: 'packaged runtime', value: packagedRuntime }
+])
+
+const result = validateBuiltVersion(packageJson, release, appManifest, [
+  { label: 'packaged runtime', value: packagedRuntime },
+  { label: 'generated runtime', value: readJson('public/version.json') }
+])
+
+console.log(`Binary version contract passed for ${result.version}.`)

--- a/scripts/release/validate-version.js
+++ b/scripts/release/validate-version.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { validateReleaseMetadata } = require('./version-contract')
+
+const repositoryRoot = path.resolve(__dirname, '..', '..')
+const packageJson = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'))
+const release = JSON.parse(fs.readFileSync(path.join(repositoryRoot, 'release.json'), 'utf8'))
+const result = validateReleaseMetadata(packageJson, release)
+
+console.log(`Release version: ${result.version}`)
+console.log(`Release channel: ${result.channel}`)
+console.log(`Native installer version: ${result.nativeVersion}`)
+console.log(`Release target: ${result.target}`)

--- a/scripts/release/version-contract.js
+++ b/scripts/release/version-contract.js
@@ -1,0 +1,173 @@
+'use strict'
+
+const SHA_PATTERN = /^[0-9a-f]{7,40}$/
+const BUILD_TIME_PATTERN = /^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})$/
+const SEMVER_PATTERN = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+
+function parseVersion (value, label = 'version') {
+  if (typeof value !== 'string' || value.startsWith('v')) {
+    throw new Error(`${label} must be a strict SemVer string without a v prefix`)
+  }
+
+  const match = SEMVER_PATTERN.exec(value)
+  if (!match) {
+    throw new Error(`${label} is not strict SemVer: ${value}`)
+  }
+  return {
+    raw: value,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split('.') : [],
+    build: match[5] ? match[5].split('.') : []
+  }
+}
+
+function releaseChannel (value) {
+  const parsed = parseVersion(value)
+  return parsed.prerelease.length ? String(parsed.prerelease[0]) : 'stable'
+}
+
+function nativeVersion (value) {
+  const parsed = parseVersion(value)
+  return `${parsed.major}.${parsed.minor}.${parsed.patch}`
+}
+
+function validateSha (value, label) {
+  if (typeof value !== 'string' || !SHA_PATTERN.test(value)) {
+    throw new Error(`${label} must be a 7-40 character lowercase Git SHA`)
+  }
+  return value
+}
+
+function validateBuildTime (value) {
+  const match = typeof value === 'string' && BUILD_TIME_PATTERN.exec(value)
+  if (!match) {
+    throw new Error('buildTime must use YYYYMMDDHHmm')
+  }
+  const [year, month, day, hour, minute] = match.slice(1).map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day, hour, minute))
+  if (year < 1970 ||
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() !== month - 1 ||
+      date.getUTCDate() !== day ||
+      date.getUTCHours() !== hour ||
+      date.getUTCMinutes() !== minute) {
+    throw new Error(`buildTime is not a real calendar date and time: ${value}`)
+  }
+  return value
+}
+
+function validateReleaseRequest ({ newTag, expectedVersion, buildCommit, sourceCommit, stable = false }) {
+  if (newTag === undefined) {
+    if (stable) throw new Error('--stable requires --newTag')
+    return
+  }
+
+  const parsedTag = parseVersion(newTag, 'release tag')
+  if (newTag !== expectedVersion) {
+    throw new Error(`Release tag must match declared version: ${expectedVersion}`)
+  }
+  if (buildCommit === undefined) {
+    throw new Error('--newTag requires --SHA7 so release provenance is immutable')
+  }
+  if (sourceCommit === undefined) {
+    throw new Error('--newTag requires --sourceSHA7 so source provenance is explicit')
+  }
+  validateSha(buildCommit, 'buildCommit')
+  validateSha(sourceCommit, 'sourceCommit')
+  if (stable && parsedTag.prerelease.length) {
+    throw new Error('--stable cannot be used with a prerelease tag')
+  }
+}
+
+function runtimeVersion ({ packageVersion, newTag, buildTime, buildCommit, sourceCommit }) {
+  const parsedPackage = parseVersion(packageVersion, 'package version')
+  const timestamp = validateBuildTime(buildTime)
+  const commit = validateSha(buildCommit, 'buildCommit')
+  const source = validateSha(sourceCommit, 'sourceCommit')
+
+  if (newTag !== undefined) {
+    const parsedTag = parseVersion(newTag, 'release tag')
+    return {
+      packageVer: newTag,
+      channel: releaseChannel(newTag),
+      buildTime: timestamp,
+      buildCommit: commit,
+      sourceCommit: source,
+      version: parsedTag.raw
+    }
+  }
+
+  const coreVersion = parsedPackage.prerelease.length
+    ? `${parsedPackage.major}.${parsedPackage.minor}.${parsedPackage.patch}`
+    : `${parsedPackage.major}.${parsedPackage.minor}.${parsedPackage.patch + 1}`
+
+  return {
+    packageVer: parsedPackage.raw,
+    channel: 'nightly',
+    buildTime: timestamp,
+    buildCommit: commit,
+    sourceCommit: source,
+    version: `${coreVersion}-nightly-${timestamp}`
+  }
+}
+
+function validateReleaseMetadata (packageJson, release) {
+  if (!packageJson || !release) throw new Error('Missing release metadata')
+  if (release.targetTagName !== 'main') {
+    throw new Error('release.targetTagName must be main')
+  }
+
+  const packageVersion = parseVersion(packageJson.version, 'package version').raw
+  const releaseVersion = parseVersion(release.newTagName, 'release tag').raw
+  if (packageVersion !== releaseVersion) {
+    throw new Error(`Version mismatch: package=${packageVersion}, release=${releaseVersion}`)
+  }
+
+  return {
+    version: releaseVersion,
+    channel: releaseChannel(releaseVersion),
+    nativeVersion: nativeVersion(releaseVersion),
+    target: release.targetTagName
+  }
+}
+
+function validateBuiltVersion (packageJson, release, appManifest, runtimeVersions) {
+  const metadata = validateReleaseMetadata(packageJson, release)
+  if (!appManifest || appManifest.version !== metadata.version) {
+    throw new Error(`Packaged app version mismatch: ${appManifest && appManifest.version}`)
+  }
+  if (!Array.isArray(runtimeVersions) || runtimeVersions.length === 0) {
+    throw new Error('At least one generated runtime version is required')
+  }
+
+  for (const entry of runtimeVersions) {
+    const label = entry && entry.label
+    const value = entry && entry.value
+    if (!label || !value) throw new Error('Malformed runtime version input')
+    if (value.packageVer !== metadata.version || value.version !== metadata.version) {
+      throw new Error(`${label} version does not match ${metadata.version}`)
+    }
+    if (value.channel !== metadata.channel) {
+      throw new Error(`${label} channel does not match ${metadata.channel}`)
+    }
+    validateBuildTime(value.buildTime)
+    validateSha(value.buildCommit, `${label} buildCommit`)
+    validateSha(value.sourceCommit, `${label} sourceCommit`)
+  }
+
+  return metadata
+}
+
+module.exports = {
+  nativeVersion,
+  parseVersion,
+  releaseChannel,
+  runtimeVersion,
+  validateBuiltVersion,
+  validateBuildTime,
+  validateReleaseMetadata,
+  validateReleaseRequest,
+  validateSha
+}

--- a/update-version.js
+++ b/update-version.js
@@ -1,98 +1,108 @@
 'use strict'
 
-const { exec } = require('child_process')
+const { execFile } = require('child_process')
 const fs = require('fs')
+const minimist = require('minimist')
+const {
+  runtimeVersion,
+  validateBuildTime,
+  validateReleaseMetadata,
+  validateReleaseRequest,
+  validateSha
+} = require('./scripts/release/version-contract')
 
 const versionJSON = './public/version.json'
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'))
+const release = JSON.parse(fs.readFileSync('release.json', 'utf8'))
+const releaseMetadata = validateReleaseMetadata(packageJson, release)
+const unpackagedVersionObj = JSON.parse(
+  fs.readFileSync('dist/electron/UnPackaged/version.json', 'utf8')
+)
 
-const unpackagedVersionJSON = fs.readFileSync('dist/electron/UnPackaged/version.json')
-const unpackagedVersionObj = JSON.parse(unpackagedVersionJSON)
-const content = {
-  packageVer: '',
-  channel: '',
-  buildTime: '',
-  buildCommit: '',
-  sourceCommit: '',
-  version: ''
-}
-const getBuildTime = async () => {
+function git (...args) {
   return new Promise((resolve, reject) => {
-    let command
-    if (process.platform === 'win32') command = 'set TZ=UTC-8 && git log -1 --date=format-local:"%Y%m%d%H%M" --format="%cd"'
-    else command = 'TZ=UTC-8 git log -1 --date=format-local:"%Y%m%d%H%M" --format="%cd"'
-    exec(command, (error, stdout, stderr) => {
+    execFile('git', args, {
+      env: { ...process.env, TZ: 'UTC-8' },
+      encoding: 'utf8'
+    }, (error, stdout, stderr) => {
       if (error) {
-        console.error(`exec error: ${error}`)
-        return
-      }
-      if (stderr) {
-        console.error(`Error from Git: ${stderr}`)
+        reject(new Error(`Git failed: ${stderr.trim() || error.message}`))
         return
       }
       resolve(stdout.trim())
     })
   })
 }
-const getCommit = async () => {
-  return new Promise((resolve, reject) => {
-    exec('git rev-parse --short HEAD', (error, stdout, stderr) => {
-      if (error) {
-        console.error(`exec error: ${error}`)
-        return
-      }
-      if (stderr) {
-        console.error(`Error from Git: ${stderr}`)
-        return
-      }
-      resolve(stdout.trim())
-    })
-  })
-}
-const getSourceCommit = async () => {
-  return new Promise((resolve, reject) => {
-    exec('git log -5 --pretty=%B --author=Alphabiz-Team', (error, stdout, stderr) => {
-      if (error) {
-        console.error(`exec error: ${error}`)
-        return
-      }
-      if (stderr) {
-        console.error(`Error from Git: ${stderr}`)
-        return
-      }
-      const sha7 = /(?<=-)\w{7}(?=\s)|^\w{7}(?=\s)|^\w{7}/gm.exec(stdout.trim())
-      resolve(sha7[0])
-    })
-  })
-}
-const updateVersionJSON = async () => {
-  // console.log(unpackagedVersionObj)
-  const zVersion = unpackagedVersionObj.packageVer.match(/(\d+)(?!.*\d)/gm)
-  const UnstableVersion = unpackagedVersionObj.packageVer.replace(/(\d+)(?!.*\d)/, Number(zVersion[0]) + 1)
 
-  content.packageVer = unpackagedVersionObj.packageVer
-  content.buildTime = await getBuildTime()
-  content.channel = 'nightly'
-  content.sourceCommit = await getSourceCommit()
-  // 如果正式发布,则从argv传入新的tagname format: node update-version.js --newTag [newTagName] --SHA7 [newSHA7] --buildTime [buildTime]
-  const argv = require('minimist')(process.argv.slice(2), { string: ['newTag', 'SHA7', 'buildTime'] })
-  console.log(argv)
-  if (process.argv.includes('--buildTime')) content.buildTime = argv.buildTime
-  // 如果正式发布buildCommit 为触发正式发布的sha7
-  if (process.argv.includes('--SHA7')) content.buildCommit = argv.SHA7
-  else content.buildCommit = await getCommit()
-  // get newTag
-  if (!process.argv.includes('--newTag')) {
-    content.version = UnstableVersion + '-' + content.channel + '-' + content.buildTime
-  } else {
-    if (process.argv.includes('--stable')) {
-      content.channel = 'stable'
-      // 正式发布通过push release.json触发，版本更新后需要手动更新public repo和private repo 的package.json的version,同步版本号
-      content.packageVer = argv.newTag
-    }
-    content.version = argv.newTag
+async function getBuildTime () {
+  return validateBuildTime(await git(
+    'log',
+    '-1',
+    '--date=format-local:%Y%m%d%H%M',
+    '--format=%cd'
+  ))
+}
+
+async function getCommit () {
+  return validateSha(await git('rev-parse', '--short=8', 'HEAD'), 'buildCommit')
+}
+
+async function assertCurrentCommit (value) {
+  const resolved = await git('rev-parse', '--verify', `${value}^{commit}`)
+  const head = await git('rev-parse', 'HEAD')
+  if (resolved !== head) {
+    throw new Error(`buildCommit must resolve to current HEAD: ${head}`)
   }
-  const data = JSON.stringify(content, null, 2)
-  fs.writeFileSync(versionJSON, data)
 }
 
-updateVersionJSON()
+async function updateVersionJSON () {
+  const argv = minimist(process.argv.slice(2), {
+    string: ['newTag', 'SHA7', 'sourceSHA7', 'buildTime'],
+    boolean: ['stable']
+  })
+
+  validateReleaseRequest({
+    newTag: argv.newTag,
+    expectedVersion: releaseMetadata.version,
+    buildCommit: argv.SHA7,
+    sourceCommit: argv.sourceSHA7,
+    stable: argv.stable
+  })
+
+  const buildTime = argv.buildTime === undefined
+    ? await getBuildTime()
+    : validateBuildTime(argv.buildTime)
+  const buildCommit = argv.SHA7 === undefined
+    ? await getCommit()
+    : validateSha(argv.SHA7, 'buildCommit')
+  if (argv.SHA7 !== undefined) await assertCurrentCommit(buildCommit)
+  if (argv.newTag !== undefined && argv.buildTime !== undefined) {
+    const commitBuildTime = await getBuildTime()
+    if (buildTime !== commitBuildTime) {
+      throw new Error(`release buildTime must match current HEAD: ${commitBuildTime}`)
+    }
+  }
+
+  let sourceCommit
+  if (argv.sourceSHA7 !== undefined) {
+    sourceCommit = validateSha(argv.sourceSHA7, 'sourceCommit')
+  } else if (/^[0-9a-f]{7,40}$/.test(unpackagedVersionObj.sourceCommit || '')) {
+    sourceCommit = unpackagedVersionObj.sourceCommit
+  } else {
+    sourceCommit = buildCommit
+  }
+
+  const content = runtimeVersion({
+    packageVersion: packageJson.version,
+    newTag: argv.newTag,
+    buildTime,
+    buildCommit,
+    sourceCommit
+  })
+  fs.writeFileSync(versionJSON, `${JSON.stringify(content, null, 2)}\n`)
+}
+
+updateVersionJSON().catch((error) => {
+  console.error(error.message)
+  process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

- align package and release metadata on 0.4.0-beta.1
- replace brittle prerelease generation with strict SemVer, commit, source, and build-time validation
- require the declared tag, current HEAD, and explicit source commit for release metadata
- add separate metadata and binary version contracts

## Safety boundary

This PR does not create a tag, publish a release, or alter bundled application files. The binary contract currently fails closed because the packaged input is still version 0.2.4; it must only pass after an audited clean rebuild produces matching 0.4.0-beta.1 runtime metadata.

## Verification

- release version contract passed
- metadata validator passed
- stale binary metadata was rejected as expected
- all existing security regressions passed; the loopback compatibility probe passed outside the restricted sandbox
- credential scan checked 900 tracked files
- release test discovery found the installed-app suite
- JavaScript syntax and focused static checks passed
- git diff check passed