### PR TITLE
docs: correct toolchain, links and defaults across the build guides

### DIFF
--- a/developer/take-down.js
+++ b/developer/take-down.js
@@ -16,9 +16,11 @@ module.exports = {
   mode: 'committee',
   /**
    * @type { string[] }
-   * Preset keys of admins.
-   * Note that you should use pubkey, not id.
-   * Type `lib.user.is.pub` in main-process devtools console to get your pubkey.
+   * Preset admin pubkeys (use pubkeys, not ids; type `lib.user.is.pub` in the
+   * main-process devtools console to print yours).
+   * FORKS: replace this whole list with your own pubkey(s). The first entry is the
+   * upstream Alphabiz administrator key; in 'committee' mode it keeps a take-down
+   * vote in your app until you remove it. See docs/en_us/fork-checklist.md.
    */
   admins: [
     'FQi3UfsB5zY7SSfLMPdl9Fdh7_EeM4og0ZGivp4tfJU.yXhvCAmmUz1Pw9-Iwhf9hpo9-H4WDHwezzRAGE5Oipk',

--- a/docs/en_us/README.md
+++ b/docs/en_us/README.md
@@ -96,7 +96,7 @@ There are some explanations for keys in `app.js`. The defaults below are transcr
 | `appId` | `'com.zeeis.alphabiz'` | Application ID for your mobile app (Android/iOS). |
 | `appIdentifier` | `'org.zeeis.alphabiz'` | Bundle identifier for your macOS app (Mac App Store). `appId` and `appIdentifier` intentionally use different prefixes; use the identifiers you registered. |
 | `snapName` | `'alphabiz'` (`name` in lower case) | Binary name of the snap package; it launches your app from a terminal. |
-| `microsoftStoreProductId` | `'9PBCCV3MHK04'` | Microsoft Store product ID; **change or clear before shipping** — the default is Alphabiz's own listing. |
+| `microsoftStoreProductId` | `'9PBCCV3MHK04'` | Store product ID used by the `appx` target; **change or clear before shipping** — the default is Alphabiz's own listing. |
 | `appxPackageIdentityName` | `'Alphabiz'` | Package identity name for the `appx` target. |
 | `publisher` | `'CN=zeeis'` | Publisher subject for the external APPX signing certificate verified through the `ALPHABIZ_APPX_*` environment variables. |
 | `publisherDisplayName` | `'Alphabiz Team'` | Publisher display name for the `appx` target. |
@@ -159,7 +159,19 @@ yarn make
 
 Platform notes:
 
-- **Windows** — plain `yarn make` currently requires the `ALPHABIZ_APPX_*` signing variables described in [windows.md](windows.md#about-appx-target) and exits before packaging anything when they are missing; `yarn make:win` builds the EXE and MSI and then fails at its final `make:appx` step for the same reason. For unsigned EXE and MSI installers run `yarn make:squirrel && yarn make:msi` instead (the MSI step needs WiX on your `PATH`).
+- **Windows** — plain `yarn make` currently requires the `ALPHABIZ_APPX_*` signing variables described in [windows.md](windows.md#about-appx-target): on Windows it checks for the certificate before it packages anything, so without them it exits immediately and `yarn make:win` fails at its first step. Without a certificate you can still build the MSI, and the EXE with one extra copy:
+
+  ```powershell
+  # MSI: reads the packager output from dist/electron/ directly (WiX 3.11 on your PATH)
+  yarn make:msi
+
+  # EXE (Squirrel): electron-forge looks in Forge's out/ directory, which `yarn make`
+  # normally fills from dist/electron/ before running the makers, so copy it yourself
+  robocopy dist\electron\Alphabiz-win32-x64 out\Alphabiz-win32-x64 /E
+  yarn make:squirrel
+  ```
+
+  Substitute your own `displayName` and architecture in the copy step. Installers land in `out/installers/<version>/`.
 - **macOS** — the DMG is unsigned unless `APPLE_ID` is set; the `premake:dmg` step skips signing without it, and users of an unsigned DMG see a Gatekeeper warning. A universal build needs both the x64 and the arm64 packager output first (`BUILD_ARCH=x64` and `BUILD_ARCH=arm64`); `./build-scripts/macos/app/build.sh` and `./build-scripts/macos/dmg/build.sh` run the three builds in order. For Mac App Store builds see [build-mac.md](build-mac.md).
 - **Linux** — `yarn make` produces a `.deb`, which needs the optional dependencies: install with plain `yarn`, not `yarn --ignore-optional`. `yarn make` does not build a snap; run `yarn make:snap` (needs snapd, Snapcraft and Multipass), or `yarn make:snap:ci` inside containers and CI runners where Multipass is unavailable (it builds with LXD).
 

--- a/docs/en_us/README.md
+++ b/docs/en_us/README.md
@@ -1,22 +1,29 @@
+> 中文文档：[docs/README.md](../README.md#中文文档)
+
 # Guide to build your own app based on Alphabiz
 
 ## Prerequisites
 
-Currently Alphabiz supports developing `Windows(x86_64)`/`Linux(x86_64)`/`macOS(x86_64/arm64/universal)` apps. For macOS app you may need a macOS device or building app by `Github Actions`.
+Currently Alphabiz supports developing `Windows (x86_64; arm64 MSI with WiX 3.14)` / `Linux (x86_64)` / `macOS (x86_64/arm64/universal)` apps. For macOS apps you need a macOS device or a macOS runner on GitHub Actions.
 
-> We recommends using `Windows 10/11`/`Ubuntu 18.04+`/`macOS 12+` to build apps.
+> We recommend using `Windows 10/11`, `Ubuntu 22.04+` or `macOS 12+` to build apps.
+
+This repository uses two toolchains. Keep them apart when you read version numbers elsewhere in the repository:
+
+- **Repository tooling and CI**: Node.js 22, Yarn Classic 1.22.22 via corepack (or `npx --yes yarn@1.22.22 <command>`); Yarn 2+ is not supported. This is what `.github/workflows/ci.yml` runs (`yarn install --ignore-scripts`, the security and release-metadata checks); it never rebuilds native modules and never packages the application.
+- **Application build** (this guide): Yarn Classic 1.22.22; Python 3.7–3.11 (node-gyp 9.3 does not support Python 3.12 or newer); a C++ toolchain (Visual Studio Build Tools on Windows, Xcode Command Line Tools on macOS, `build-essential` on Linux); native modules are rebuilt for the `@zeeis/velectron` 21.3.3 runtime (the `electron` devDependency pin is overridden by the postinstall symlink). Node.js: the shipped releases were built with Node.js 16, which the former nightly pipeline pinned; newer Node.js versions have not been re-verified for the native module rebuild — if you build successfully on a newer version, please report it.
 
 Before developing, you need to install:
 
-- Git
-- [NodeJS](http://nodejs.org) >= 16
-- Yarn >= 1.21
-- Python >= 3.7
-- [node-gyp](https://github.com/nodejs/node-gyp)
+- [Git](https://git-scm.com) — clone the repository; a downloaded source ZIP has no `.git` directory and fails at the `preunpackaged` step
+- [Node.js](https://nodejs.org/en/download) — see the toolchain note above
+- Yarn Classic 1.22.22 — `corepack enable && corepack prepare yarn@1.22.22 --activate`
+- [Python](https://www.python.org/downloads/) 3.7–3.11
+- [node-gyp](https://github.com/nodejs/node-gyp) with a working C++ compiler
 
-For windows you need:
+For Windows you need:
 - Visual Studio Build Tools
-- [WiX Toolset](https://wixtoolset.org) 3.11
+- [WiX Toolset](https://github.com/wixtoolset/wix3/releases) v3.11 (v3.14 for arm64 MSI); do not install WiX v4 or newer
 
 See [windows](windows.md) for more details.
 
@@ -25,7 +32,7 @@ For Linux you need:
   ```sh
   sudo apt install build-essential
   ```
-- snap
+- snap, Snapcraft and Multipass (only needed for `yarn make:snap`)
   ```sh
   sudo apt install snapd
   ```
@@ -39,49 +46,76 @@ For Linux you need:
   ```
 
 For macOS you need:
-- [XCode](https://developer.apple.com/xcode/) with Command Line Tools
+- [Xcode](https://developer.apple.com/xcode/) with Command Line Tools
 
 ## Fork and prepare your project
 
-- Click the `Fork` button in github page, change the name to what you want, and then click `Create Fork` to fork this repo.
-- Clone your forked repo to your local machine
+- Click the `Fork` button in the GitHub page, change the name to what you want, and then click `Create Fork` to fork this repo.
+- Clone your forked repo to your local machine (clone it; do not download a source ZIP)
   ```sh
   git clone git@github.com:your_username/your_appname.git
   ```
-- Installing dependencies
+- Install dependencies
   ```sh
   yarn
   yarn unpackaged
   ```
 
-## Customize your app
-- Edit [developer/app.js](developer/app.js) via your IDE.
-- Edit [developer/assets](developer/assets) and [developer/platform-assets](developer/platform-assets) to change icons and other assets for your app.
+  Run both commands from the repository root. The application bundle depends on two packages
+  published to GitHub Packages (`@zeeis/alphabiz-account`, `@zeeis/alphabiz-libdb`), and that
+  registry requires a token even for public packages, so `yarn unpackaged` needs a GitHub personal
+  access token with the `read:packages` scope in `~/.npmrc`:
 
-There are some explainations for keys in `app.js`.
+  ```txt
+  //npm.pkg.github.com/:_authToken=YOUR_TOKEN
+  ```
+
+  Put it in `~/.npmrc`, not in the repository's own `.npmrc`. The root `yarn` step reads the same
+  file, because the `@zeeis/velectron` installer that fetches the custom Electron runtime looks
+  there; the runtime itself is a public download, so an empty value on that line is enough for
+  `yarn` alone. Never write a placeholder after `=`: a non-empty invalid token causes a 401.
+
+  If you change `version` in package.json, set the same string as `newTagName` in
+  release.json and keep `targetTagName` as `main`; otherwise `yarn unpackaged` stops
+  with `Version mismatch`.
+
+## Customize your app
+- Edit [developer/app.js](../../developer/app.js) via your IDE.
+- Edit [developer/assets](../../developer/assets) and [developer/platform-assets](../../developer/platform-assets) to change icons and other assets for your app.
+
+There are some explanations for keys in `app.js`. The defaults below are transcribed from `developer/app.js`; entries marked **change before shipping** point at Alphabiz's own services or identities.
 
 | Key | Default/Value | Description |
 | --- | --- | --- |
-| `name` | `"Alphabiz"` | Your app name. We recommend using only alphabet characters(a-z and A-Z) and at lease 3 characters. |
-| `displayName` | `"Alphabiz"` | This name is a more general name that will be used as title, process name and other that you can find in app. |
-| `fileName` | `"Alphabiz"` | This name is used to build installers. For macOS this should be up to 15 characters. |
-| `description` | `String` | Description for your app |
-| `author` | `"Alphabiz Team <dev@alpha.biz>"` | Author name. Commonly is `YOUR_ORG_NAME <EMAIL>` |
-| `developer` | `"Alphabiz Team"` | Author name without special characters(`<` `>`, etc.) |
-| `appId` | `"com.zeeis.alphabiz"` | The appid for your mobile app (iOS/Android) |
-| `appIdentifier` | `"com.zeeis.alphabiz"` | The appid for your mac app |
-| `microsoftStoreProductId` | `String` | The appid for your win store app |
-| `appxPackageIdentityName` | `"Alphabiz"` | The appid for your appx target|
-| `publisher` | `"CN=zeeis"` | Publisher subject for the external APPX signing certificate verified through the `ALPHABIZ_APPX_*` environment variables |
-| `publisherDisplayName` | `"Alphabiz Team"` | The publisher name for win store |
-| `upgradeCode` | `String` | An uuid used by msi target to identify same app.<br> Run `npx uuid v4` to generate your owns |
-| `homepage` | `"https://alpha.biz"` | Your official site for your app |
-| `protocol` | `"alphabiz"` | The universal link protocol that can open your app |
-| `shortProtocol` | `"ab"` | A short protocol same as `protocol` |
-| `versionsUrl` | `String` | An url to a `versions.json` that can controls force-update |
-| `twitterAccount` | `"@alphabiz"` | Your official twitter account |
-| `register` | `Object` | Configure users in which areas can register accounts in your app |
-| `theme` | `Object` | Colors for your app. See [Theme Builder](https://m3.material.io/theme-builder) and color tools in development pannel |
+| `name` | `'Alphabiz'` | Your app name. We recommend using only alphabet characters (a-z and A-Z) and at least 3 characters. |
+| `displayName` | `'Alphabiz'` | A more general name used as the window title, process name and elsewhere in the app. |
+| `fileName` | `'Alphabiz'` | Used to name installers. For macOS this should be up to 15 characters. |
+| `description` | `'Alphabiz Blockchain Cryptocurrency Application'` | Description for your app. |
+| `author` | `'Alphabiz Team <dev@alpha.biz>'` | Author. Commonly `YOUR_ORG_NAME <EMAIL>`. |
+| `developer` | `'Alphabiz Team'` | Author name without special characters (`<` `>`, etc.). |
+| `appId` | `'com.zeeis.alphabiz'` | Application ID for your mobile app (Android/iOS). |
+| `appIdentifier` | `'org.zeeis.alphabiz'` | Bundle identifier for your macOS app (Mac App Store). `appId` and `appIdentifier` intentionally use different prefixes; use the identifiers you registered. |
+| `snapName` | `'alphabiz'` (`name` in lower case) | Binary name of the snap package; it launches your app from a terminal. |
+| `microsoftStoreProductId` | `'9PBCCV3MHK04'` | Microsoft Store product ID; **change or clear before shipping** — the default is Alphabiz's own listing. |
+| `appxPackageIdentityName` | `'Alphabiz'` | Package identity name for the `appx` target. |
+| `publisher` | `'CN=zeeis'` | Publisher subject for the external APPX signing certificate verified through the `ALPHABIZ_APPX_*` environment variables. |
+| `publisherDisplayName` | `'Alphabiz Team'` | Publisher display name for the `appx` target. |
+| `upgradeCode` | `'4d8a65aa-fc5b-421c-94ab-cb722ef737e2'` | UUID the MSI target uses to recognise the same app across versions; **change before shipping** (run `npx uuid v4`), otherwise Windows treats your app and Alphabiz as the same product. |
+| `homepage` | `'https://alpha.biz'` | Official site for your app (also written into the `.deb` metadata). |
+| `webEditionUrl` | `'https://web.alpha.biz'` | URL of the web edition the app links to. |
+| `protocol` | `'alphabiz'` (`name` in lower case) | URL protocol that opens your app (`alphabiz://`). |
+| `shortProtocol` | `'ab'` | Short protocol with the same purpose as `protocol` (`ab://`). |
+| `versionsUrl` | `'https://raw.githubusercontent.com/tanshuai/alphabiz/main/versions.json'` | URL of the `versions.json` that controls force-update; **change before shipping** — point it at your own repository. |
+| `twitterAccount` | `'@alphabiz_app'` | Your official Twitter account. |
+| `register` | `{ mode: 'none', list: [] }` | Which countries can register accounts in your app: `mode` is `'none'`, `'blacklist'` or `'whitelist'`; `list` holds ISO 3166-1 alpha-2 codes. |
+| `library.recommends` | `{ default: ['fxpebrsi9ij5pzinwdky', 'cut44dbbfxjpqka39qix'], 'zh-CN': ['vs52l0yqtqqpqtw33ycx', 'cut44dbbfxjpqka39qix'] }` | Channel IDs auto-selected as recommended channels, keyed by `navigator.language`. The defaults are Alphabiz's channels; **change or empty them before shipping**. |
+| `update` | `require('./update')` | Update sources; see [About app update](#about-app-update). |
+| `takedown` | `require('./take-down')` | Take-down administrators and presets; see [About library take-down](#about-library-take-down). |
+| `theme` | `Object` | Colors for your app. See [Theme Builder](https://m3.material.io/theme-builder) and the color tools in the development panel. |
+| `dynamicConfig` | `require('./dynamicConfig')` | Runtime configuration; `remote.url` defaults to Alphabiz's endpoint (`alpha.biz/app/remote_config`), **change before shipping**. See [Dynamic configs](#dynamic-configs). |
+| `communities` | `[{ enable: true, url: 'https://github.com/tanshuai/alphabiz', icon: 'https://github.githubassets.com/favicons/favicon.svg' }]` | Community links shown next to the version label (a drop-down list when there is more than one); `enable: false` hides an entry without removing it. The default links to this repository; **change before shipping**. |
+| `externalI18n` | `'https://raw.githubusercontent.com/tanshuai/alphabiz/main/i18n'` | Raw URL of the external i18n directory loaded at boot; **change before shipping** — otherwise your app loads Alphabiz's translations. See [About external i18n](#about-external-i18n). |
+| `LIBDB_NAME` | `'Alphabiz'` (`app.name`) | Not a key of the exported object: `app.js` sets `global.LIBDB_NAME = app.name`, and `alphabiz-libdb` uses it as the internal library category so that different builds keep separate libraries. Append a suffix if two of your builds share one `name`. |
 
 There are icons used by app
 ```tree
@@ -107,7 +141,7 @@ developer/
 |   |   |   ├── Square44x44Logo.png       # APPX installer icon
 |   |   |   └── Square44x44Logo.targetsize-44_altform-unplated.png    # APPX tray icon
 |   |   └── splash/
-|   |   |   ├── InstallSplash.gif         # EXE(Squirel) installer gif
+|   |   |   ├── InstallSplash.gif         # EXE(Squirrel) installer gif
 |   |   |   ├── background_493x312.png    # MSI installer background
 |   |   |   └── banner_493x58.png         # MSI installer banner
 ├── favicon.ico                           # App favicon
@@ -116,26 +150,32 @@ developer/
 
 ## Build your app
 
+Run these from the repository root, after `yarn` and `yarn unpackaged`:
+
 ```sh
 yarn packager
 yarn make
 ```
 
-For building Mac App Store app, see [this document](build-mac.md).
+Platform notes:
+
+- **Windows** — plain `yarn make` currently requires the `ALPHABIZ_APPX_*` signing variables described in [windows.md](windows.md#about-appx-target) and exits before packaging anything when they are missing; `yarn make:win` builds the EXE and MSI and then fails at its final `make:appx` step for the same reason. For unsigned EXE and MSI installers run `yarn make:squirrel && yarn make:msi` instead (the MSI step needs WiX on your `PATH`).
+- **macOS** — the DMG is unsigned unless `APPLE_ID` is set; the `premake:dmg` step skips signing without it, and users of an unsigned DMG see a Gatekeeper warning. A universal build needs both the x64 and the arm64 packager output first (`BUILD_ARCH=x64` and `BUILD_ARCH=arm64`); `./build-scripts/macos/app/build.sh` and `./build-scripts/macos/dmg/build.sh` run the three builds in order. For Mac App Store builds see [build-mac.md](build-mac.md).
+- **Linux** — `yarn make` produces a `.deb`, which needs the optional dependencies: install with plain `yarn`, not `yarn --ignore-optional`. `yarn make` does not build a snap; run `yarn make:snap` (needs snapd, Snapcraft and Multipass), or `yarn make:snap:ci` inside containers and CI runners where Multipass is unavailable (it builds with LXD).
 
 After building Windows installers, some files are modified by the build scripts.
 
-- appx/template.xml
+- build-scripts/windows/appx/template.xml
 - package.json
 
-You can use reset the changes by running
+You can reset the changes by running
 ```sh
-git reset FILE_NAME
+git restore FILE_NAME
 ```
 
 or running
 ```sh
-node make --reset
+node build-scripts/common/make.js --reset
 ```
 
 You can find installers in `out/installers/VERSION`.
@@ -148,9 +188,9 @@ View comments in `developer/app.js` for more information.
 
 ### About app update
 
-You can edit `developer/update.js` to tell your app how to check and download updates. Currently we supports using `Github` and `Amazon S3`.
+You can edit `developer/update.js` to tell your app how to check and download updates. Currently we support using `GitHub` and `Amazon S3`.
 
-You can use the `versionsUrl` to configure force-update. The default url links to `versions.json` file in root directory of this repo.
+You can use the `versionsUrl` to configure force-update. The default URL points at the `versions.json` file in the root directory of this repository (`main` branch); point it at your own repository before shipping.
 ```json
 {
   "min": {
@@ -169,22 +209,28 @@ You can configure who can register an account for your app by editing the `regis
 
 The `developer/dynamicConfig.js` includes some dynamic configs that can be changed at runtime.
 
-The app first loads `local` entry when launch, and then makes a request to `remote.url` to get remote configs and saves to local.
+The app first loads the `local` entry when it launches, and then makes a request to `remote.url` to get remote configs and saves them locally. The default `remote.url` is Alphabiz's endpoint; point it at your own before shipping.
 
 ### About library take-down
 
-The `developer/take-down.js` includes configs to take-down users, channels or posts for media library. This can help you manage user-created contents in your app. You need to create your own account and copy your account pub key to `admins` to add permission for your.
+The `developer/take-down.js` includes configs to take down users, channels or posts in the media library. This can help you manage user-created contents in your app. Replace the contents of `admins` with your own pubkey(s); the shipped list starts with the upstream Alphabiz administrator key, which in the default `committee` mode keeps a take-down vote in your app until you remove it. Type `lib.user.is.pub` in the main-process devtools console to print your own pubkey.
 
-The `developer/take-down.json` includes presets for take-downed contents.
+The `developer/take-down.json` includes presets for taken-down contents.
 
 ## About external i18n
 
-You can edit the [i18n](../../i18n/README.md) directory in this repo to add more internationality files. These files will be loaded when app boot, and can be updated without updating your app.
+You can edit the [i18n](../../i18n/README.md) directory in this repo to add more internationality files. These files will be loaded when the app boots, and can be updated without updating your app.
+
+Point `externalI18n` in `developer/app.js` at your own repository's raw URL (for GitHub use the `raw.githubusercontent.com/YOUR_USERNAME/YOUR_REPO/main/i18n` form, not `github.com/...`), otherwise your app loads Alphabiz's translations from this repository's `main` branch.
 
 For more information, view the [README](../../i18n/README.md) file in `i18n`.
 
 ## About term-of-service
 
-The default ToS file [here](../../developer/terms-of-service.md) uses `Alphabiz` as app name and `Alphabiz Team` as developer name. You need to change them manually.
+The default ToS file [here](../../developer/terms-of-service.md) uses `Alphabiz` as the app name, `Alphabiz Team` as the developer name and names `Tan Shuai` as the operator. Replace `Alphabiz`, `Alphabiz Team` and `Tan Shuai` with your own names before shipping.
 
 You can use `Ctrl+F` to search or `Ctrl+H` to replace.
+
+## Before you ship
+
+Work through the [fork checklist](fork-checklist.md): the repository and update sources, `versionsUrl`, `externalI18n`, the Store product ID, `upgradeCode`, take-down admins, recommended channels, community links and the ToS names all default to Alphabiz's own values.

--- a/docs/en_us/build-mac.md
+++ b/docs/en_us/build-mac.md
@@ -1,4 +1,4 @@
-# Guild to build macOS .app .dmg and mas target
+# Guide to build macOS .app .dmg and mas target
 
 ## One-command maker
 
@@ -7,6 +7,8 @@
 ```
 
 This command will build mac `.app` and `.dmg` files, both with `x86_64`, `arm64` and `universal` targets. If you want to build specific version, read the sh file for more details.
+
+The `.dmg` files are unsigned unless `APPLE_ID` is set: without `APPLE_ID`/`APPLE_ASP` in `.env` (the build scripts load `.env` from the repository root; export the variables in your shell if you run `yarn make` directly) the `premake:dmg` step skips signing and produces an unsigned dmg, which Gatekeeper warns about on first launch.
 
 ## CodeSign for mas(Mac App Store)
 
@@ -25,7 +27,7 @@ APP="Alphabiz"
 # Platform should be `mas` for Mac App Store, or `darwin` for 3rd party package.
 BUILD_PLATFORM="mas"
 # This overrides `version` in `package.json`
-VERSION="0.2.4"
+VERSION="0.3.3"  # match the release you are submitting
 # Increase this value everytime for a new submission to MAS.
 BUILD_BUNDLE="1"
 # The distribution key you get from App Store Connect

--- a/docs/en_us/build-mac.md
+++ b/docs/en_us/build-mac.md
@@ -8,7 +8,7 @@
 
 This command will build mac `.app` and `.dmg` files, both with `x86_64`, `arm64` and `universal` targets. If you want to build specific version, read the sh file for more details.
 
-The `.dmg` files are unsigned unless `APPLE_ID` is set: without `APPLE_ID`/`APPLE_ASP` in `.env` (the build scripts load `.env` from the repository root; export the variables in your shell if you run `yarn make` directly) the `premake:dmg` step skips signing and produces an unsigned dmg, which Gatekeeper warns about on first launch.
+The `.dmg` files are unsigned unless `APPLE_ID` is set: `premake:dmg` tests only `APPLE_ID`, so without it in `.env` (the build scripts load `.env` from the repository root; export the variables in your shell if you run `yarn make` directly) the signing step is skipped and an unsigned dmg is produced, which Gatekeeper warns about on first launch. `APPLE_ASP` is read only for notarization and validation in `build-scripts/macos/pkg/build.sh`; with `APPLE_ID` set and `APPLE_ASP` missing, signing still runs and `build-scripts/macos/pkg/sign.sh` stops at its own environment checks.
 
 ## CodeSign for mas(Mac App Store)
 

--- a/docs/en_us/windows.md
+++ b/docs/en_us/windows.md
@@ -4,11 +4,11 @@
 
 ## Prerequisites
 
-Ensure you have installed [git](https://git-scm.com), [python3](https://www.python.org/downloads/) and [nodejs](http://nodejs.org) >= 16 and added them to your PATH.
+Ensure you have installed [git](https://git-scm.com), [Python](https://www.python.org/downloads/) 3.7–3.11 (node-gyp 9.3 does not support Python 3.12 or newer) and [Node.js](https://nodejs.org/en/download), and added them to your PATH. Two toolchains apply, see the [README prerequisites](README.md#prerequisites): repository tooling and CI use Node.js 22 with Yarn Classic 1.22.22; the application build uses Yarn Classic 1.22.22 and rebuilds native modules for the `@zeeis/velectron` 21.3.3 runtime. The shipped releases were built with Node.js 16; newer Node.js versions have not been re-verified for the native module rebuild — if you build successfully on a newer version, please report it.
 
 You'll need [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools) to build app. The `.Net Frameworks` and `C++ Desktop Development` are required.
 
-We recommend using `yarn` as your package manager. Since `node.js` 16+ it it bundled in node, and you can enable yarn by just running `corepack enable`.
+We recommend using Yarn Classic as your package manager. Node.js ships corepack, so enable the pinned version by running `corepack enable && corepack prepare yarn@1.22.22 --activate` (or run commands through `npx --yes yarn@1.22.22`); Yarn 2+ is not supported.
 
 (Optional) You can install `@quasar/cli` for dev.
 ```sh
@@ -17,15 +17,15 @@ yarn global add @quasar/cli
 
 ## `msi` target
 
-For building MSI installers, you should also install [WiX Toolset](https://wixtoolset.org) and add the install path to your PATH. The default install path should be something like `C:\Program Files (x86)\WiX Toolset v3.11\bin`.
+For building MSI installers, you should also install [WiX Toolset](https://github.com/wixtoolset/wix3/releases) v3.11 and add the install path to your PATH. The default install path should be something like `C:\Program Files (x86)\WiX Toolset v3.11\bin`. Do not install WiX v4 or newer: the MSI maker used here needs the v3 tools.
 
 ### MSI for Arm64
 
-Normaly you will get `3.11` from Wix's website, but this version does not support `arm64`.
+Normally you will get `3.11` from WiX's website, but this version does not support `arm64`.
 
-The `arm64` support was added since `3.14`, which is not released to github.
+The `arm64` support was added in `3.14`, which is published on the WiX v3 GitHub releases page rather than on the WiX website.
 
-You can download above version from [here](https://wixtoolset.org/docs/v3/releases/v3-14-0-6526/).
+Download it from [github.com/wixtoolset/wix3/releases](https://github.com/wixtoolset/wix3/releases): tag `wix3141rtm` (WiX Toolset v3.14.1; `wix314rtm` is v3.14.0).
 
 ## About `appx` target
 
@@ -33,6 +33,9 @@ The `appx` installer is a wrapper for Universal Windows Platform apps (also
 known as Microsoft Store apps). Every APPX build must use an explicitly
 configured signing certificate. This repository does not contain a default or
 test signing key.
+
+Plain `yarn make` and `yarn make:win` currently require these variables; for
+unsigned EXE and MSI installers run `yarn make:squirrel && yarn make:msi`.
 
 Store a password-protected PFX outside the repository. Provide its absolute
 path, password, and approved SHA-256 certificate fingerprint for the current
@@ -48,7 +51,7 @@ yarn make:appx
 The certificate subject must match `publisher` in `developer/app.js`. The
 preflight check rejects relative paths, missing files, non-PFX files,
 certificates inside the repository, empty passwords, fingerprint mismatches,
-and the retired legacy development certificate. The APPX maker is not added to
+and the retired development certificate. The APPX maker is not added to
 the Forge configuration unless all three values pass verification, so a direct
 Forge command cannot fall back to an automatically generated certificate.
 

--- a/docs/en_us/windows.md
+++ b/docs/en_us/windows.md
@@ -34,8 +34,18 @@ known as Microsoft Store apps). Every APPX build must use an explicitly
 configured signing certificate. This repository does not contain a default or
 test signing key.
 
-Plain `yarn make` and `yarn make:win` currently require these variables; for
-unsigned EXE and MSI installers run `yarn make:squirrel && yarn make:msi`.
+Plain `yarn make` and `yarn make:win` currently require the `ALPHABIZ_APPX_*`
+variables shown below: the certificate is checked before packaging, so without
+them `yarn make` exits immediately and `yarn make:win` fails at its first step.
+For an unsigned build, `yarn make:msi` works on its own because it reads the
+packager output from `dist/electron/` directly. The Squirrel EXE maker instead
+reads Forge's `out/` directory, which `yarn make` normally fills from
+`dist/electron/`, so copy it there first:
+
+```powershell
+robocopy dist\electron\Alphabiz-win32-x64 out\Alphabiz-win32-x64 /E
+yarn make:squirrel
+```
 
 Store a password-protected PFX outside the repository. Provide its absolute
 path, password, and approved SHA-256 certificate fingerprint for the current

--- a/docs/zh_cn/build-app.md
+++ b/docs/zh_cn/build-app.md
@@ -72,6 +72,13 @@ cp ./build-scripts/macos/.env ./.env
 (5).运行结束后在`out/installers/[app版本号]`路径下生成 x64、amd64、universal版本的dmg安装包
 
 ### 3. mac商店版本
+
+请参考 [build-mac.md](../en_us/build-mac.md)（英文）。
+
 ### 4. Android
 
+公共仓库当前不提供移动端构建文档；移动端由上游应用仓库构建。
+
 ### 5. IOS
+
+公共仓库当前不提供移动端构建文档；移动端由上游应用仓库构建。

--- a/docs/zh_cn/customized-content.md
+++ b/docs/zh_cn/customized-content.md
@@ -21,17 +21,25 @@ webEditionUrl | `https://web.alpha.biz` | (字符串) - 网页版客户端。
 upgradeCode | `4d8a65aa-fc5b-421c-94ab-cb722ef737e2` | (字符串) - Windows 升级码。如果两个应用程序有相同的代码，Windows 将删除旧的安装时。您可以通过运行命令 `npx uuid v4` 创建自己的代码。
 protocol | `alphabiz` | (字符串) - 链接协议。默认情况下，应用程序将注册 `alphabiz://` 作为它的url协议。**注意，至少3个字符，只能使用a-z，不能与微软商店保留的协议重复，不能与链接协议缩写重复**
 shortProtocol | `ab` | (字符串) - 链接协议缩写，默认使用 `ab://` **注意，至少2个字符，只能使用a-z，不能与微软商店保留的协议重复，不能与链接协议、app名称重复**
-versionsUrl | `https://raw.githubusercontent.com/  tanshuai/alphabiz/main/versions.json` | (字符串) - 应用程序检查该文件，判断是否需要强制更新，<a href="#forced-update">见此</a>
+versionsUrl | `https://raw.githubusercontent.com/tanshuai/alphabiz/main/versions.json` | (字符串) - 应用程序检查该文件，判断是否需要强制更新，<a href="#forced-update">见此</a>
 twitterAccount | `@alphabiz_app` | (字符串) - 用于反馈功能的推特账号
 LIBDB_NAME | `[APP名称]` | (字符串) - 用于区分不同的媒体库。当应用程序名称相同时想要使用不同的媒体库时，您可以向 `LIBDB_NAME` 添加一个尾部来分隔库。
 microsoftStoreProductId | `9PBCCV3MHK04` | (字符串) - 微软商店产品 ID。
+communities | `[{ enable: true, url: 'https://github.com/tanshuai/alphabiz', icon: 'https://github.githubassets.com/favicons/favicon.svg' }]` | (数组) - 社区链接（如 Discord）。图标显示在应用右上角版本标签旁，点击后在浏览器中打开链接；`icon` 可以是图片 url 或 base64 字符串；`enable: false` 可隐藏图标而不删除配置；多于一个时显示为下拉列表。**默认指向上游 Alphabiz 仓库，fork 后请替换为你自己的社区链接。**
+externalI18n | `https://raw.githubusercontent.com/tanshuai/alphabiz/main/i18n` | (字符串) - 外部 i18n 目录地址，目录结构见 [i18n](../../i18n/README.md)。若用 GitHub 托管，需使用 `raw.githubusercontent.com` 而不是 `github.com`。**fork 后请改为你自己仓库的 raw 地址，否则你的应用会从上游 Alphabiz 仓库的 `main` 分支加载翻译。**
 
 **register(object):** 配置哪个地区的用户可以使用你的应用程序
 
 | Key | Default | Description |
 | :---- | :---- | :---- |
 mode | `none` | (字符串) - `none`: 任何人都可以注册；`blacklist`: 名单中的国家将被禁用；`whitelist`: 只启用名单中的国家。**注意，启用白名单时，list至少包含一个国家代码**
-list | `['US', 'CN']` | (数组) - 国家代码列表，必须是 GeoIP ISO 3166-1-alpha-2 代码，[见此](http://www.geonames.org/countries/)
+list | `[]` | (数组) - 国家代码列表（例如 `['US', 'CN']`），必须是 GeoIP ISO 3166-1-alpha-2 代码，[见此](http://www.geonames.org/countries/)
+
+**library(object):** 媒体库
+
+| Key | Default | Description |
+| :---- | :---- | :---- |
+recommends | `{ default: ['fxpebrsi9ij5pzinwdky', 'cut44dbbfxjpqka39qix'], 'zh-CN': ['vs52l0yqtqqpqtw33ycx', 'cut44dbbfxjpqka39qix'] }` | (对象) - 按语言预置的推荐频道 id 列表，应用按 `navigator.language`（而不是设置中选择的语言）匹配。**默认是上游 Alphabiz 的频道，fork 后请替换或清空。**
 
 **theme(object):** 主题
 
@@ -44,7 +52,7 @@ accent | `#fbbb4a` | (字符串) - 强调主题颜色
 **cornerLogoStyle**|  | 应用程序侧边栏左上角图标背景,修改下面的参数对位置进行微调
 left | `-72px` | (字符串) - 水平方向
 top | `-92px` | (字符串) - 垂直方向
-height | `-245px` |  (字符串) - 图标大小
+height | `245px` |  (字符串) - 图标大小
 
 ## 2. <span id="update-channel">更新通道信息 `update.js`</span>
 
@@ -61,7 +69,7 @@ internalRepo | `alphabiz-app` | (字符串) - Internal 版本发布所在仓库�
 bucketUrl | `https://s3.amazonaws.com/internal.alpha.biz` | (字符串) - 内部版本更新通道-S3 储存桶链接，若不使用 S3 储存桶，则设置为`''`空字符串，例如`bucketUrl: ''`。
 s3DownloadUrl| `https://d2v5t3td4po4es.cloudfront.net/releases/` | (字符串) - 可使用 AWS CloudFront 全球加速生成的 URL，若不使用 CloudFront，则修改为 [S3 bucket url] + [正确路径]。
 
-**版本号规则，<a href="https://github.com/zeeis/customization-test/tree/main/docs/zh_cn/fork-repo-hint.md#version">见此</a>**
+**版本号规则，<a href="./fork-repo-hint.md#version">见此</a>**
 
 ## 3. 动态配置文件 `dynamicConfig.js`
 
@@ -145,7 +153,7 @@ developer/                                # 定制化文件夹
 Key | Default | Description
 :---- | :---- | :----
 mode | `committee` | (字符串) - `admin` 频道被管理员投了一票后，将被下架; `committee` 半数及以上的委员会成员对频道投票后，该频道将会下架
-admins | ['an_id_of_admin', 'an_id_of_other_admin' ] | (数组) - 管理员的预设键列表。**注意，应该使用pubkey，而不是id。导入媒体库密钥后，在主进程的devtools控制台输入`lib.user.is.pub`，获得当前导入密钥的pubkey**
+admins | `['<上游 Alphabiz 管理员 pubkey>', 'an_id_of_admin', 'an_id_of_other_admin']` | (数组) - 管理员的预设公钥列表。**请把 admins 整个列表替换为你自己的 pubkey；默认第一项是上游 Alphabiz 管理员公钥，committee 模式下它会保留一票下架投票权。注意，应该使用pubkey，而不是id。导入媒体库密钥后，在主进程的devtools控制台输入`lib.user.is.pub`，获得当前导入密钥的pubkey**
 
 #### (2) ` take-down.json `
 
@@ -170,7 +178,7 @@ electron-packager的详细配置可以参考[此处](https://electron.github.io/
 
 electron-forge详细配置可以参考[此处](https://www.electronforge.io/config/makers)
 
-app安装包图标的配置可以参考<a href="https://github.com/zeeis/customization-test/blob/main/docs/zh_cn/customized-content.md#app-icon">此处</a>
+app安装包图标的配置可以参考<a href="#app-icon">此处</a>
 
 ```bash
 build-scripts/

--- a/docs/zh_cn/development-issues-solutions.md
+++ b/docs/zh_cn/development-issues-solutions.md
@@ -26,7 +26,7 @@ Request failed \"401 Unauthorized\"".
 **报错原因**：未安装好编译C++所需的工具，或node-gyp electron-rebuild出问题
 
 **解决方案**：
-1. 安装好[编译C++所需的工具](https://github.com/zeeis/customization-test/tree/main/docs/zh_cn/fork-repo-hint.md#build-c++)后，重试`yarn`
+1. 安装好[编译C++所需的工具](./prepare-before-dev.md#build-c++)后，重试`yarn`
 2. 若还是失败，可以尝试清空仓库根目录的node_modules文件夹和node-gyp缓存文件。
 
 ```bash
@@ -58,7 +58,7 @@ Output:
 RequestError: read ECONNRESET
 ```
 
-#### (4). 时区报错
+#### (5). 时区报错
 
 **报错原因**：
 1. 系统时间变化：如果你的系统时间突然变化（比如夏令时变化，手动调整，NTP更新等），可能会导致此问题。
@@ -69,7 +69,7 @@ RequestError: read ECONNRESET
 
 错误信息：
 ```
-yarn install v1.22.19
+yarn install v1.22.22
 [1/5] Validating package.json...
 [2/5] Resolving packages...
 [3/5] Fetching packages...
@@ -130,7 +130,7 @@ channel | (字符串) - 默认版本通道，建议与版本号中的通道统�
 buildTime | (字符串) - 软件构建时间。github仓库最后一次commit的时间
 buildCommit | (字符串) - 软件构建github提交记录。github仓库最后一次commit的SHA7，显示在APP标题栏，方便查找版本
 sourceCommit | (字符串) - 软件资源github提交记录。若是私有仓库，则与buildCommit相同；若是公共仓库，则为私有仓库最后一次commit的SHA7，方便查找公共仓库发布的软件对应的私有仓库的提交记录
-version | (字符串) - 完整版本号，规则 <a href="#version">见此</a>
+version | (字符串) - 完整版本号，规则 <a href="./fork-repo-hint.md#version">见此</a>
 
 #### (2). digital envelope routines::unsupported
 
@@ -138,9 +138,7 @@ version | (字符串) - 完整版本号，规则 <a href="#version">见此</a>
 
 > Webpack 导致的 openssl 问题已修复，如果安装新模块后出现报错，检查新引入的模块是否使用了 `crypto` 模块中的旧加密方法
 
-**解决方案**：
-  方法1: node版本重装成16的
-  方法2: 打开终端并粘贴如下所示
+**解决方案**：设置 `NODE_OPTIONS` 环境变量（值见下方对应平台的命令）后重试。打开终端并粘贴如下所示：
 
 Linux and macOS (Windows Git Bash)-
 ```

--- a/docs/zh_cn/development-issues-solutions.md
+++ b/docs/zh_cn/development-issues-solutions.md
@@ -138,7 +138,7 @@ version | (字符串) - 完整版本号，规则 <a href="./fork-repo-hint.md#ve
 
 > Webpack 导致的 openssl 问题已修复，如果安装新模块后出现报错，检查新引入的模块是否使用了 `crypto` 模块中的旧加密方法
 
-**解决方案**：设置 `NODE_OPTIONS` 环境变量（值见下方对应平台的命令）后重试。打开终端并粘贴如下所示：
+**解决方案**：把 `NODE_OPTIONS` 环境变量设为 `--openssl-legacy-provider` 后重试。打开终端并粘贴如下所示：
 
 Linux and macOS (Windows Git Bash)-
 ```

--- a/docs/zh_cn/development-issues-solutions.md
+++ b/docs/zh_cn/development-issues-solutions.md
@@ -10,10 +10,10 @@
 
 #### <span id="401-unauthorized">(2). 401 Unauthorized </span>
 
-**报错原因**：没有权限安装alphabiz的模块。Github PAT密钥没有配置好、或没有加入zeeis组织
+**报错原因**：`dist/electron/UnPackaged` 的两个应用包发布在 GitHub Packages 上，该 registry 即使对公开包也要求 token。通常是 `~/.npmrc` 里没有配置带 `read:packages` 权限的 PAT，或者填了一个非空但无效的 token。
 
 **解决方案**：
-1. 查看[github PAT密钥配置文档](https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/use-github-pat.md)
+1. 查看 [PAT 配置文档](./use-github-pat.md)
 2. 与alphabiz仓库[所有者](https://github.com/tanshuai)联系
 
 

--- a/docs/zh_cn/fork-private-repo.md
+++ b/docs/zh_cn/fork-private-repo.md
@@ -2,6 +2,8 @@
 
 私有仓库地址: [alphabiz-app](https://github.com/tanshuai/alphabiz-app)
 
+> 本文档面向拥有上游应用仓库访问权限的维护者；外部开发者请使用 [fork-public-repo.md](./fork-public-repo.md)。
+
 ## 开发前的准备
 
 请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/prepare-before-dev.md"  target="_blank">此文档</a> 进行开发前的准备。
@@ -42,7 +44,7 @@ yarn dev
 
 ### 6.定制 app
 
-使用记事本或[代码编辑器](https://github.com/zeeis/customization-test/tree/main/docs/zh_cn/fork-repo-hint.md#code-editor)工具，修改`developer/`配置文件。等待 Electron 窗口刷新，若没有可以按 F5 手动刷新。调试完代码后，请使用 Ctrl + C 关闭 dev 模式。
+使用记事本或[代码编辑器](./prepare-before-dev.md#code-editor)工具，修改`developer/`配置文件。等待 Electron 窗口刷新，若没有可以按 F5 手动刷新。调试完代码后，请使用 Ctrl + C 关闭 dev 模式。
 
 详细定制化配置信息请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/customized-content.md">此文档</a>
 
@@ -54,8 +56,8 @@ yarn dev
 yarn build
 ```
 
-1. app 生成路径为`dist/electron/[app 名称]-[系统名称]`。
-2. 如需修改构建 app 安装包的配置，请参考 [此文档](https://github.com/zeeis/customization-test/blob/main/docs/zh_cn/customized-content.md#install-package-config)
+1. app 生成路径为`dist/electron/[app 名称]-[系统名称]-[arch]`。
+2. 如需修改构建 app 安装包的配置，请参考 [此文档](./customized-content.md#install-package-config)
 
 ### 8.生成安装包
 

--- a/docs/zh_cn/fork-public-repo.md
+++ b/docs/zh_cn/fork-public-repo.md
@@ -32,7 +32,7 @@ yarn
 
 ### 5.安装 unpackaged 文件的 Node.js 模块
 
-公共仓库中的 `dist/electron/UnPackaged` 是由上游应用仓库构建产出的应用包，需要单独安装它的 Node.js 模块。它依赖的两个应用包（`@zeeis/alphabiz-account`、`@zeeis/alphabiz-libdb`）已随仓库 `vendor/` 目录一起提供，无需 GitHub PAT。在仓库根目录打开命令行，并执行以下命令：
+公共仓库中的 `dist/electron/UnPackaged` 是由上游应用仓库构建产出的应用包，需要单独安装它的 Node.js 模块。它依赖的两个应用包（`@zeeis/alphabiz-account`、`@zeeis/alphabiz-libdb`）发布在 GitHub Packages 上，该 registry 即使对公开包也要求 token，因此需要在 `~/.npmrc` 中配置带 `read:packages` 权限的 PAT，见 [use-github-pat.md](./use-github-pat.md)。在仓库根目录打开命令行，并执行以下命令：
 
 ```bash
 yarn unpackaged

--- a/docs/zh_cn/fork-public-repo.md
+++ b/docs/zh_cn/fork-public-repo.md
@@ -62,7 +62,7 @@ yarn make
 ```
 注意以下内容：
 - 安装包存储路径为`out/installers/[app版本号]`
-- 在 Windows 上，`yarn make` 会在打包前检查 APPX 签名证书：需要通过 `ALPHABIZ_APPX_PFX_PATH`、`ALPHABIZ_APPX_PFX_PASSWORD`、`ALPHABIZ_APPX_CERT_SHA256` 提供仓库外部的证书（见 [appx 安装包](./customized-content.md#9-appx安装包)）。如果只需要未签名的 EXE 与 MSI，请改用 `yarn make:squirrel && yarn make:msi`。
+- 在 Windows 上，`yarn make` 会在打包前检查 APPX 签名证书：需要通过 `ALPHABIZ_APPX_PFX_PATH`、`ALPHABIZ_APPX_PFX_PASSWORD`、`ALPHABIZ_APPX_CERT_SHA256` 提供仓库外部的证书（见 [appx 安装包](./customized-content.md#9-appx%E5%AE%89%E8%A3%85%E5%8C%85)）。没有证书时，`yarn make:msi` 可以单独运行（它直接读取 `dist/electron/` 下的打包产物）；Squirrel 的 EXE 打包器读取 electron-forge 的 `out/` 目录，而该目录平时由 `yarn make` 从 `dist/electron/` 复制填充，因此需要先手动复制一次：`robocopy dist\electron\Alphabiz-win32-x64 out\Alphabiz-win32-x64 /E`，再运行 `yarn make:squirrel`（请把名称与架构替换为你自己的）。
 - 如果需要在 Windows 上生成安装包，请先安装<a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/prepare-before-dev.md#7-%E5%9C%A8-windows-%E7%B3%BB%E7%BB%9F%E4%B8%8B%E9%9C%80%E8%A6%81%E5%AE%89%E8%A3%85-wix-toolset">Wix Toolset</a>
 - 如果在`yarn make`过程中使用 Ctrl+C 强制退出，可能导致部分动态修改的文件无法恢复。如遇到此问题，请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/fork-repo-hint.md#4-%E6%81%A2%E5%A4%8D%E8%A2%AB%E5%8A%A8%E6%80%81%E4%BF%AE%E6%94%B9%E7%9A%84%E6%96%87%E4%BB%B6-">这里</a> 解决。
 - 在 Windows 系统下，可能会因为 Windows 路径长度限制而导致 yarn make 报错，提示某个文件路径过长。如遇到此问题，请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/development-issues-solutions.md#3-windows%E7%B3%BB%E7%BB%9F%E6%96%87%E4%BB%B6%E8%B7%AF%E5%BE%84%E8%BF%87%E9%95%BF-">这里</a> 解除路径长度限制。

--- a/docs/zh_cn/fork-public-repo.md
+++ b/docs/zh_cn/fork-public-repo.md
@@ -32,7 +32,7 @@ yarn
 
 ### 5.安装 unpackaged 文件的 Node.js 模块
 
-由于公共仓库的代码是私有仓库预编译过的代码，需要安装预编译代码的模块，在仓库根目录打开命令行，并执行以下命令：
+公共仓库中的 `dist/electron/UnPackaged` 是由上游应用仓库构建产出的应用包，需要单独安装它的 Node.js 模块。它依赖的两个应用包（`@zeeis/alphabiz-account`、`@zeeis/alphabiz-libdb`）已随仓库 `vendor/` 目录一起提供，无需 GitHub PAT。在仓库根目录打开命令行，并执行以下命令：
 
 ```bash
 yarn unpackaged
@@ -40,7 +40,7 @@ yarn unpackaged
 
 ### 6.定制 app
 
-请使用记事本或[代码编辑器](https://github.com/zeeis/customization-test/tree/main/docs/zh_cn/fork-repo-hint.md#code-editor)工具，修改`developer/`配置文件。详细定制化配置信息请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/customized-content.md">此文档</a> 。
+请使用记事本或[代码编辑器](./prepare-before-dev.md#code-editor)工具，修改`developer/`配置文件。详细定制化配置信息请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/customized-content.md">此文档</a> 。
 
 ### 7.构建 app
 
@@ -49,7 +49,7 @@ yarn unpackaged
 yarn packager
 ```
 注意以下内容：
-- 生成的 app 存储路径为`build/electron/[app名称]-[系统名称]`
+- 生成的 app 存储路径为`dist/electron/[displayName]-[platform]-[arch]`
 - 暂定调试流程:
   1. 重复执行步骤 7 和 8，检查新生成的 app。
   2. 修改配置后，开启 e2e 测试的 debug 模式并查看配置修改情况。可以通过 ctrl+c 关闭运行的命令行或关闭运行中的 electron 和 playwright 窗口，并重复操作 `yarn test:e2e:electron:custom --debug`
@@ -62,6 +62,7 @@ yarn make
 ```
 注意以下内容：
 - 安装包存储路径为`out/installers/[app版本号]`
+- 在 Windows 上，`yarn make` 会在打包前检查 APPX 签名证书：需要通过 `ALPHABIZ_APPX_PFX_PATH`、`ALPHABIZ_APPX_PFX_PASSWORD`、`ALPHABIZ_APPX_CERT_SHA256` 提供仓库外部的证书（见 [appx 安装包](./customized-content.md#9-appx安装包)）。如果只需要未签名的 EXE 与 MSI，请改用 `yarn make:squirrel && yarn make:msi`。
 - 如果需要在 Windows 上生成安装包，请先安装<a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/prepare-before-dev.md#7-%E5%9C%A8-windows-%E7%B3%BB%E7%BB%9F%E4%B8%8B%E9%9C%80%E8%A6%81%E5%AE%89%E8%A3%85-wix-toolset">Wix Toolset</a>
 - 如果在`yarn make`过程中使用 Ctrl+C 强制退出，可能导致部分动态修改的文件无法恢复。如遇到此问题，请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/fork-repo-hint.md#4-%E6%81%A2%E5%A4%8D%E8%A2%AB%E5%8A%A8%E6%80%81%E4%BF%AE%E6%94%B9%E7%9A%84%E6%96%87%E4%BB%B6-">这里</a> 解决。
 - 在 Windows 系统下，可能会因为 Windows 路径长度限制而导致 yarn make 报错，提示某个文件路径过长。如遇到此问题，请参考 <a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/development-issues-solutions.md#3-windows%E7%B3%BB%E7%BB%9F%E6%96%87%E4%BB%B6%E8%B7%AF%E5%BE%84%E8%BF%87%E9%95%BF-">这里</a> 解除路径长度限制。
@@ -81,5 +82,5 @@ yarn make
 ```bash
 yarn node copy-patch.js --post
 ```
-5. 每次提交代码时都会运行测试用例，每晚会执行用于发布 nightly 版本的工作流。具体内容请参考[这里](https://github.com/tanshuai/alphabiz/blob/main/.github/workflows/release-nightly.yml)。
+5. 每次 push／PR 到 main 会运行 CI 与 CodeQL，具体内容请参考[这里](../../.github/workflows/ci.yml)；nightly 发布流水线已暂停，历史 nightly 版本见 [Releases](https://github.com/tanshuai/alphabiz/releases)。
 6. 如果工作流中包含自动提交 commit 的步骤，建议统一设置 Actions Runner 的时区为东八区，以方便管理版本号中的日期。具体设置方法请参考<a href="https://github.com/tanshuai/alphabiz/blob/main/docs/zh_cn/fork-repo-hint.md#7-workflow%E8%AE%BE%E7%BD%AE%E6%97%B6%E5%8C%BA%E6%AD%A5%E9%AA%A4-">此文档</a>

--- a/docs/zh_cn/fork-repo-hint.md
+++ b/docs/zh_cn/fork-repo-hint.md
@@ -13,7 +13,7 @@
 
 (3).点击[Create fork]按钮。创建fork
 
-截图以`zeeis/customization-test`仓库为例
+截图以一个示例 fork 为例
 
 ![image](https://user-images.githubusercontent.com/92558550/202063641-d763dea6-8583-4cac-8b57-39ec8860bd96.png)
 
@@ -47,7 +47,7 @@
 
 可以在[View conflicts]按钮中快速找到发生冲突的文件
 
-<img width="722" alt="1e023a3636086f7b6c436758363093f" src="https://github.com/zeeis/customization-test/assets/92558550/712a4321-a90b-4545-9f94-d6c1e5e956ad">
+（示意：在 GitHub Desktop 的冲突提示中点击【View conflicts】，会列出带三角形感叹号的冲突文件，可直接从列表中打开）
 
 <img width="805" alt="d89e1b0540f0fb834b915479438058d" src="https://user-images.githubusercontent.com/92558550/202371563-42d4fc80-41d3-4938-9a74-b6ad35442d83.png">
 
@@ -82,7 +82,7 @@
 
 <img width="764" alt="c2fa9cfc756564ca2b7198e98d4c910" src="https://user-images.githubusercontent.com/92558550/201564728-51366560-3bc5-4e32-b93f-5148a398a484.png">
 
-<img width="391" alt="48b7ccbf90af5c5fced9579e9bb67cf" src="https://github.com/zeeis/customization-test/assets/92558550/1aa7262b-5cc2-4adf-aa97-08d264b7eef9">
+（示意：在 GitHub Desktop 的【Clone a repository】窗口切换到【URL】标签，粘贴仓库 url，并在【Local path】中选择本地文件夹）
 
 然后根据自己需求，修改本地文件夹的路径或名称
 
@@ -120,7 +120,7 @@ github Desktop恢复文件方法： 在被修改的文件中，右键目标文�
 命令行恢复文件方法： (确保package.json没有其他修改内容，以免恢复文件后，其他修改被恢复)
 
 ```bash
-yarn node make.js --reset
+node build-scripts/common/make.js --reset
 ```
 
 ### 5. <span id="github-release">手动发布github release: </span>
@@ -228,7 +228,7 @@ ubuntu-latest runner
 
 日期统一格式为：yyyymmddhhmmss，时区统一为东八区
 
-如果要在应用中使用版本更新功能，则需要在 Github Releases 上发布自己的版本。详细信息请参考[alphabiz releases](https://github.com/tanshuai/alphabiz/releases)，并更改更新通道信息。具体方法请参见[此处](https://github.com/zeeis/customization-test/blob/main/docs/zh_cn/customized-content.md#update-channel)。需要注意以下几点：
+如果要在应用中使用版本更新功能，则需要在 Github Releases 上发布自己的版本。详细信息请参考[alphabiz releases](https://github.com/tanshuai/alphabiz/releases)，并更改更新通道信息。具体方法请参见[此处](./customized-content.md#update-channel)。需要注意以下几点：
 
 1. tag标签名称: 版本号
 2. assets(上传资源名称): [app名称]-版本名称.(安装包拓展名)(deb | dmg | msi)

--- a/docs/zh_cn/prepare-before-dev.md
+++ b/docs/zh_cn/prepare-before-dev.md
@@ -4,7 +4,12 @@
 可以在命令行中输入 `git --version` 来检查是否已安装。推荐使用 [Github Desktop 工具](https://desktop.github.com/)。
 #### (2). 确保已经安装了 Node.js。
 
-建议安装版本为 16，可以在命令行中输入 `node -v` 和 `npm -v` 来检查是否已安装。如果需要管理多个 Node.js 版本，可以使用 [nvm](https://github.com/nvm-sh/nvm) 工具。可以从 [这里](https://nodejs.org/download/release/v16.19.0/) 下载 Node.js 16.19.0 安装包。
+可以在命令行中输入 `node -v` 和 `npm -v` 来检查是否已安装。如果需要管理多个 Node.js 版本，可以使用 [nvm](https://github.com/nvm-sh/nvm) 工具。安装包可以从 [Node.js 官方下载页](https://nodejs.org/en/download) 获取。
+
+本仓库有两套工具链，请按你的目的选择 Node.js 版本：
+
+- 仓库工具链与 CI：Node.js 22，Yarn Classic 1.22.22（corepack 或 `npx --yes yarn@1.22.22`；不支持 Yarn 2+）。
+- 应用构建：Yarn Classic 1.22.22；Python 3.7–3.11（node-gyp 9.3 不支持 3.12 及以上）；C++ 工具链；原生模块按 `@zeeis/velectron` 21.3.3 运行时重新编译；Node.js：已发布版本使用 Node.js 16 构建（旧 nightly 流水线固定为 16），更高版本尚未针对原生模块重编译重新验证——若你在新版本上构建成功，欢迎反馈。
 
 <details><summary>Git 和 Node.js 的安装方法（点击查看）</summary>
 
@@ -17,13 +22,13 @@
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
    ```
 
-3. 使用以下命令在终端中安装 Git 和 Node.js 16：
+3. 使用以下命令在终端中安装 Git；Node.js 请按上文「两套工具链」说明选择版本，从 [Node.js 官方下载页](https://nodejs.org/en/download) 下载安装包，或用 nvm 安装（例如 `nvm install 16`）：
 
    ```bash
-   brew install git node@16
+   brew install git
    ```
 
-4. 找到nodejs安装的路径，添加到环境变量中
+4. 若你改用 Homebrew 安装了带版本号的 Node.js（例如 `brew install node@16`），需要找到其安装路径并添加到环境变量中
 
   ```bash
   Intel芯片为例
@@ -44,7 +49,7 @@
 1. 下载 Git for Windows 安装程序：https://git-scm.com/download/win
 2. 运行安装程序并按照提示进行操作。默认选项通常是可以接受的。
 3. 在安装过程中，确保选中“Git Bash Here”和“Use Git and optional Unix tools from the Command Prompt”选项。
-4. 下载 Node.js 16.19.0 的 MSI 安装包：https://nodejs.org/download/release/v16.19.0/
+4. 从 [Node.js 官方下载页](https://nodejs.org/en/download) 下载 Windows 安装包（版本按上文「两套工具链」说明选择）
 5. 运行安装程序并按照提示进行操作。默认选项通常是可以接受的。
 6. 等待安装完成后，您可以在命令提示符中输入以下命令来验证 Git 和 Node.js 是否已成功安装：
 
@@ -70,12 +75,10 @@
 
    ```
 
-2. 使用以下命令在终端中安装 Git 和 Node.js 16：
+2. 使用以下命令在终端中安装 Git；Node.js 请按 [Node.js 官方下载页](https://nodejs.org/en/download) 上对应你发行版的方式安装（版本按上文「两套工具链」说明选择），或用 nvm 安装（例如 `nvm install 16`）：
 
    ```bash
    sudo apt-get install git
-   curl -sL https://deb.nodesource.com/setup_16.x | sudo bash -
-   sudo apt -y install nodejs
    ```
 
 3. 等待安装过程完成。
@@ -94,7 +97,7 @@
 #### (3). <span id="build-c++">在 Windows 系统下，需要安装`Visual Studio 2015 及以上版本的桌面开发工具和 C++ 组件`以及`Python`。</span>详细请参考 [这篇文档](https://github.com/Microsoft/nodejs-guidelines/blob/master/windows-environment.md#environment-setup-and-configuration)。
 此步骤用于windows系统下，编译仓库中的C++模块
 
-安装 Python 时，需要安装版本大于等于 **3.6** 且 小于 **3.12**，并且需要勾选 **Add Python to PATH** 选项，以便操作系统可以快速找到 Python 解释器。
+安装 Python 时，需要安装版本大于等于 **3.7** 且小于 **3.12**（即 3.7–3.11；仓库锁定的 node-gyp 9.3 不支持 Python 3.12 及以上），并且需要勾选 **Add Python to PATH** 选项，以便操作系统可以快速找到 Python 解释器。
 
 注意：
 - 确保安装Visual Studio 2019或2017
@@ -123,12 +126,14 @@
 
 #### (4). 确保安装 yarn
 
-检查 yarn 的版本：`yarn -v`
+检查 yarn 的版本：`yarn -v`（应为 `1.22.22`）
 
-安装 yarn：
+本仓库使用 Yarn Classic 1.22.22，**不支持 Yarn 2+**（仓库依赖 Classic 锁文件与 hoisted `node_modules`）。推荐通过 corepack 安装：
 ```bash
-npm install --global yarn
+corepack enable
+corepack prepare yarn@1.22.22 --activate
 ```
+若无法使用 corepack，可以用 `npx --yes yarn@1.22.22 <命令>` 代替 `yarn <命令>`。
 
 #### (5). 在 fork 私有仓库时，需要安装 @quasar/cli
 
@@ -144,7 +149,7 @@ yarn global add @quasar/cli
 
 Wix Toolset 是一个用于创建 Windows 安装程序的工具集。在 Windows 系统下构建 MSI 安装包时需要使用它。
 
-安装前需要确认安装 .NET Framework 3.5.1。安装 Wix Toolset 可以从[官网](https://wixtoolset.org/)下载最新版本的 MSI 安装程序。安装完成后，需要将 Wix Toolset 的安装路径添加到系统 Path 变量中。默认情况下，Wix Toolset 的安装路径为：
+安装前需要确认安装 .NET Framework 3.5.1。请安装 **WiX Toolset v3.11（arm64 需 v3.14）——不要安装 v4 及以上**，安装程序可从 [wix3 的 GitHub Releases](https://github.com/wixtoolset/wix3/releases) 下载。安装完成后，需要将 Wix Toolset 的安装路径添加到系统 Path 变量中。默认情况下，Wix Toolset 的安装路径为：
 ```
 C:\Program Files (x86)\WiX Toolset v3.11\bin
 ```
@@ -172,7 +177,7 @@ C:\Program Files (x86)\WiX Toolset v3.11\bin
 
 <details><summary>安装Wix Toolset、配置环境变量方法(点击查看)</summary>
 
-建议安装最后一个稳定版本的exe安装包
+建议安装 v3.11 系列最后一个稳定版本的 exe 安装包（arm64 用 v3.14），不要安装 v4 及以上
 
 ![image](https://user-images.githubusercontent.com/92558550/202830934-0796cc10-e0d6-4fc6-aa5c-ba7927df3fc8.png)
 

--- a/docs/zh_cn/prepare-before-dev.md
+++ b/docs/zh_cn/prepare-before-dev.md
@@ -28,13 +28,15 @@
    brew install git
    ```
 
-4. 若你改用 Homebrew 安装了带版本号的 Node.js（例如 `brew install node@16`），需要找到其安装路径并添加到环境变量中
+4. 若你用 Homebrew 安装了带版本号的 Node.js（Homebrew 目前只提供 node@18／node@20／node@22／node@24；Node 16 请改用 nvm），需要找到其安装路径并添加到环境变量中
 
   ```bash
   Intel芯片为例
-  echo 'PATH="/usr/local/opt/node@16/bin:$PATH"' >> ~/.zshrc
-  echo 'PATH="/usr/local/opt/node@16/bin:$PATH"' >> ~/.bash_profile
+  echo 'PATH="/usr/local/opt/node@22/bin:$PATH"' >> ~/.zshrc
+  echo 'PATH="/usr/local/opt/node@22/bin:$PATH"' >> ~/.bash_profile
   ```
+
+  把 `node@22` 换成你实际安装的版本；Apple 芯片的前缀是 `/opt/homebrew/opt/`。
 
 5. 等待安装完成后，您可以通过运行以下命令来验证 Git 和 Node.js 是否已成功安装：
 

--- a/docs/zh_cn/prepare-before-dev.md
+++ b/docs/zh_cn/prepare-before-dev.md
@@ -145,7 +145,7 @@ yarn global add @quasar/cli
 ```
 
 #### (6). <span id="github-pat">生成github PAT</span>
-当前使用的一些模块仍然是 alphabiz 的私有模块，因此需要使用 zeeis 成员的 GitHub PAT。详情请参考 [这篇文档](https://github.com/zeeis/customization-test/tree/main/docs/zh_cn/use-github-pat.md)
+`dist/electron/UnPackaged` 依赖的两个应用包发布在 GitHub Packages 上，该 registry 即使对公开包也要求 token，因此需要一个带 `read:packages` 权限的 GitHub PAT。配置方法见 [use-github-pat.md](./use-github-pat.md)。
 
 #### (7). 在 Windows 系统下，需要安装 <span id="wix-tool">Wix Toolset</span>
 

--- a/docs/zh_cn/use-github-pat.md
+++ b/docs/zh_cn/use-github-pat.md
@@ -8,7 +8,7 @@
 
 - 选择 `Personal access tokens`, 选择`Tokens(classic)`, 点击 `Generate new token`, 点击 `Generate new token(classic)`
 
-- 勾选下方 `Select scopes` 中的第一项(`repo`)、第三项(`write:packages`), 点击 `Generate toke`
+- 勾选下方 `Select scopes` 中的 `read:packages`（只读安装包即可，不需要 `repo` 或 `write:packages`）, 点击 `Generate token`
 
 - 复制生成的 `token`, 此 `token` 只会展示一次, 如果不慎遗失可以重新生成
 
@@ -19,7 +19,7 @@
 **注意!!!： 是`~`目录下, 不清楚请自行查找各操作系统下`~`目录所在位置。不要修改github 仓库根目录的`.npmrc`文件，以免在后面`yarn install`时，一直出现401错误。**
 
 ``` txt
-//npm.pkg.github.com/:_authToken=YOUT_TOKEN
+//npm.pkg.github.com/:_authToken=YOUR_TOKEN
 ```
 
 - 前往`~`文件夹的命令行：
@@ -58,10 +58,3 @@ yarn
 ```
 
 `node_modules/electron` 将被重定向到 `node_modules/@zeeis/velectron`, 如出现问题可尝试移除 `node_modules` 文件夹后重试
-
-NOTE: *当前有两个可能的警告来自 `electron v11.5.0` 本身*
-
-``` txt
-electron: The default of contextIsolation is deprecated ...
-ExtensionLoadWarning: Warnings loading extension ...
-```

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,13 +1,17 @@
 # Guide for external i18n
 
-Alphabiz loads its translations from an external i18n directory at runtime, so language packs can be added or updated without shipping a new version of the app. This directory is the one Alphabiz itself loads; a fork points its app at its own copy (see [For forks](#for-forks)).
+Alphabiz ships its built-in translations inside the app and additionally loads language packs from an external i18n directory at runtime, so packs can be added or updated without shipping a new version of the app. This directory is the one Alphabiz itself loads; a fork points its app at its own copy (see [For forks](#for-forks)).
 
 ## Directory layout
 
 - [`example/translations.json`](example/translations.json) is the canonical key set. `check.js` loads it (`require('./example/translations.json')`) and validates every locale directory against it: a locale must contain every key of the example, must not contain keys that are not in the example, and every `{variable}` placeholder in an example value must also appear in the translated value. The `example` directory itself is skipped by the check.
 - [`example/dateTimeFormat.json`](example/dateTimeFormat.json) is the template for the optional date and time formats.
 - The [en-GB](en-GB) directory contains configurations for en-GB.
-- The [locales](locales) file lists the locale codes the app offers.
+- The [locales](locales) file lists the locale codes **this directory provides**. It is additive: the app already
+  ships built-in locales (de-DE, en-US, es-ES, fr-FR, hi-IN, id-ID, it-IT, ja-JP, ko-KR, nl-NL, pl-PL, pt-PT,
+  ru-RU, th-TH, tr-TR, zh-CN, zh-TW), and an entry here either adds a new locale or replaces a built-in one
+  that has the same code. Removing a code from this file, or commenting it out with `#`, only stops that
+  external pack from loading; it does not remove a built-in locale from the app.
 
 You can add your custom language in a directory named by its locale code. The locale codes are recommended to be [BCP-47 language tags](https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1).
 

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,18 +1,25 @@
 # Guide for external i18n
 
-> Use `node ./check.js` to check your i18n files for updates, and use `node ./check.js -O` to modified your files with missing keys.
+Alphabiz loads its translations from an external i18n directory at runtime, so language packs can be added or updated without shipping a new version of the app. This directory is the one Alphabiz itself loads; a fork points its app at its own copy (see [For forks](#for-forks)).
 
-The example [en-GB](en-GB) directory contains configurations for en-GB.
+## Directory layout
 
-You can add your custom language in a directory named by locale codes. The locale codes are recommended to be [BCP-47 language tags](https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1).
+- [`example/translations.json`](example/translations.json) is the canonical key set. `check.js` loads it (`require('./example/translations.json')`) and validates every locale directory against it: a locale must contain every key of the example, must not contain keys that are not in the example, and every `{variable}` placeholder in an example value must also appear in the translated value. The `example` directory itself is skipped by the check.
+- [`example/dateTimeFormat.json`](example/dateTimeFormat.json) is the template for the optional date and time formats.
+- The [en-GB](en-GB) directory contains configurations for en-GB.
+- The [locales](locales) file lists the locale codes the app offers.
 
-The [translations.json](en-GB/translations.json) is required, while [dateTimeFormat.json](en-GB/dateTimeFormat.json) is optional.
+You can add your custom language in a directory named by its locale code. The locale codes are recommended to be [BCP-47 language tags](https://gist.github.com/typpo/b2b828a35e683b9bf8db91b5404f1bd1).
 
-You can use `${displayName}` in translations and it will be replaced with real display name in runtime.
+In each locale directory, `translations.json` is required, while `dateTimeFormat.json` is optional.
 
-After adding the i18n directory, you should also add the locale code to [locales](locales). Every line in `locales` file should starts with one locale code. You can add a label for the locale.
+You can use `${displayName}` in translations and it will be replaced with the real display name at runtime.
 
-The app will fetch and read this file on startup and parse locales in it. You can just add `#` before a code in it to disable a language pack instead of remove its directory.
+## Registering a locale
+
+After adding the i18n directory, you should also add the locale code to [locales](locales). Every line in the `locales` file starts with one locale code. You can add a label for the locale.
+
+The app will fetch and read this file on startup and parse the locales in it. You can put `#` before a code in it to disable a language pack instead of removing its directory.
 
 Example:
 
@@ -24,3 +31,22 @@ ja-JP Any label with spaces are ok # But label should be as short as possible
 zh-CN
 
 ```
+
+## Checking a locale
+
+Run the checker from inside the `i18n/` directory (the script path below is relative to it):
+
+```sh
+cd i18n
+node ./check.js            # check every locale directory against example/translations.json
+node ./check.js ja-JP      # check one or more locale codes (create the directory first)
+node ./check.js -O         # also write the fixes: add missing keys (copied from the example, still to be translated) and remove keys that are not in the example
+```
+
+`node ./check.js -O` also creates `translations.json` from the example in a locale directory that does not have one yet. Missing `{variable}` placeholders are only reported: fix them by hand, because the checker does not write a file that has a placeholder problem, even with `-O`. A locale is ready when the checker prints `This language is perfectly ready for publish!` for it.
+
+## For forks
+
+Installed apps read this directory at runtime from the URL in `externalI18n` in [`developer/app.js`](../developer/app.js). The default, `https://raw.githubusercontent.com/tanshuai/alphabiz/main/i18n`, loads Alphabiz's translations from the `main` branch of this repository, so a fork that keeps the default shows Alphabiz's strings, including any later change made here. Set `externalI18n` to your own repository's raw URL; for GitHub that is `https://raw.githubusercontent.com/<user>/<repo>/<branch>/i18n`, not a `github.com/.../blob/...` URL.
+
+Two more files are fetched from GitHub at runtime in the same way. `developer/take-down.json` is loaded from `https://raw.githubusercontent.com/<github.username>/<github.repo>/<github.branch>/developer/take-down.json`, built from the `github` section of [`developer/update.js`](../developer/update.js), and `versionsUrl` in `developer/app.js` points at `versions.json`. Set `github.username`, `github.repo` and `github.branch` in `developer/update.js`, and `versionsUrl` in `developer/app.js`, to your own repository as well.


### PR DESCRIPTION
## Summary

Line-level corrections to the English and Chinese build/customization guides and the i18n guide: stale toolchain versions and dead links, `developer/app.js` defaults that the tables transcribed wrongly, missing keys, and the things a fork must change before shipping (take-down admins, `externalI18n`, update channels).

## What changed

- `docs/en_us/README.md`, `windows.md`, `build-mac.md` — two-toolchain prerequisites, the corrected unsigned-Windows build path, `developer/app.js` defaults re-transcribed from the source, seven previously undocumented keys, dead WiX and workflow links, `node build-scripts/common/make.js --reset`, the fork-checklist pointer.
- `docs/zh_cn/*.md` — the same toolchain split, live Node.js download links (the Node 16 Homebrew formula and the NodeSource `setup_16.x` script are both gone), WiX v3.11/v3.14 guidance, in-repo relative links replacing the deleted `zeeis/customization-test` references, corrected output paths, the take-down admin warning, section renumbering.
- `i18n/README.md` — the external directory is additive to the app's 17 built-in locales; `example/translations.json` documented as the key set `check.js` validates against.
- `developer/take-down.js` — comment only, telling forks to replace the whole `admins` list (the first entry is the upstream administrator key and holds a committee vote until removed). No values changed.

Toolchain wording is now split into "repository tooling and CI" (Node.js 22, Yarn Classic 1.22.22 — what `ci.yml` exercises with `--ignore-scripts`) and "application build" (Yarn Classic 1.22.22, Python 3.7–3.11, C++ toolchain, native modules rebuilt for the velectron 21.3.3 runtime; Node.js 16 is the version the shipped releases were built with — newer versions are not claimed to be verified).

## Verification

| Gate | Result |
| --- | --- |
| `git diff --check` | clean |
| `node scripts/security/scan-credentials.js` | passed (906 tracked files) |
| Banned-vocabulary grep | no hits |
| Every absolute URL added or changed | HTTP 200 (`formulae.brew.sh` re-queried: `node@16` is 404, the available versioned formulae are node@18/20/22/24) |
| Relative links and anchors | resolve in-tree |
| `developer/app.js` defaults | compared against the module's own exports |

## Compatibility and rollback

Documentation and one comment block (`developer/take-down.js`; no code or values changed). `git revert -m 1 <merge-sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Depends on

Merge after the framing pull request: `developer/take-down.js` and the English guide point at `docs/en_us/fork-checklist.md`, which that pull request adds (plan merge order 1 → 2 → 3).
