### PR TITLE
build: make unsigned Windows installers without an APPX certificate

### DIFF
--- a/build-scripts/common/electron-packager.js
+++ b/build-scripts/common/electron-packager.js
@@ -12,7 +12,11 @@ const basePath = process.env.PROD
   ? process.resourcesPath
   : process.cwd()
 const versionJSONPath = process.env.PROD ? 'version.json' : 'public/version.json'
-const versionJSON = fs.readFileSync(resolve(basePath, versionJSONPath))
+const versionJSONFile = resolve(basePath, versionJSONPath)
+if (!fs.existsSync(versionJSONFile)) {
+  throw new Error('[packager] public/version.json is missing. Run yarn unpackaged (or node update-version.js) before yarn packager.')
+}
+const versionJSON = fs.readFileSync(versionJSONFile)
 const versionObj = JSON.parse(versionJSON)
 const buildVersion = process.env.BUILD_VERSION || versionObj.version
 const buildArch = process.env.BUILD_ARCH || process.arch
@@ -260,7 +264,12 @@ const options = {
     mirrorOptions: {
       mirror: 'https://github.com/zeeis/velectron/releases/download/'
     },
-    downloader: require('@zeeis/velectron/downloader')
+    // Requiring the velectron downloader eagerly reads optional user-level
+    // auth config. Keep module load side-effect free; the actual download
+    // path remains behind the full-build gate.
+    downloader: {
+      download: (...args) => require('@zeeis/velectron/downloader').download(...args)
+    }
   },
   // asar compress all resources to app.asar, which is
   // not an accessable directory for __statics, set to

--- a/build-scripts/common/electron-packager.js
+++ b/build-scripts/common/electron-packager.js
@@ -14,7 +14,7 @@ const basePath = process.env.PROD
 const versionJSONPath = process.env.PROD ? 'version.json' : 'public/version.json'
 const versionJSONFile = resolve(basePath, versionJSONPath)
 if (!fs.existsSync(versionJSONFile)) {
-  throw new Error('[packager] public/version.json is missing. Run yarn unpackaged (or node update-version.js) before yarn packager.')
+  throw new Error(`[packager] ${versionJSONPath} is missing at ${versionJSONFile}. Run yarn unpackaged (or node update-version.js) before yarn packager.`)
 }
 const versionJSON = fs.readFileSync(versionJSONFile)
 const versionObj = JSON.parse(versionJSON)

--- a/build-scripts/common/make.js
+++ b/build-scripts/common/make.js
@@ -257,7 +257,16 @@ if (process.argv.includes('--make')) {
   if (platform === 'win32') {
     // A Windows release must never fall back to a certificate stored in Git or
     // to an interactively generated certificate that CI could upload by mistake.
-    getAppxSigningCertificate({ required: true, expectedPublisher: appConfig.publisher })
+    // Without any ALPHABIZ_APPX_* variable the APPX target is skipped; set
+    // ALPHABIZ_REQUIRE_APPX=1 to make it mandatory. Partial configuration
+    // still throws inside the helper, so the check stays fail-closed.
+    const appxSigning = getAppxSigningCertificate({
+      required: process.env.ALPHABIZ_REQUIRE_APPX === '1',
+      expectedPublisher: appConfig.publisher
+    })
+    if (!appxSigning) {
+      console.log('[appx-signing] No external APPX certificate configured; make:win builds exe + msi and skips appx (set ALPHABIZ_REQUIRE_APPX=1 to require it).')
+    }
     const xmlFilePath = resolve(__rootdir, 'build-scripts/windows/appx/template.xml')
     const oldAppxTemplate = readFileSync(resolve(__rootdir, 'build-scripts/windows/appx/template.xml'), 'utf-8')
     let appxTemplate = oldAppxTemplate

--- a/build-scripts/windows/appx/make-appx-if-configured.js
+++ b/build-scripts/windows/appx/make-appx-if-configured.js
@@ -2,13 +2,25 @@
 
 const { spawnSync } = require('child_process')
 const { validateBuildTarget } = require('../../common/command-boundary')
-const { PATH_ENV, PASSWORD_ENV, FINGERPRINT_ENV } = require('./signing-certificate')
+const {
+  PATH_ENV,
+  PASSWORD_ENV,
+  FINGERPRINT_ENV,
+  normalizeFingerprint
+} = require('./signing-certificate')
 
 const REQUIRE_ENV = 'ALPHABIZ_REQUIRE_APPX'
-const CERTIFICATE_ENVS = [PATH_ENV, PASSWORD_ENV, FINGERPRINT_ENV]
 
+// Mirrors `anyConfigured` in signing-certificate.js: the fingerprint is
+// normalized there before it counts as configured, so a value with no hex
+// digits must not make this script disagree with make.js about whether the
+// APPX step is expected to run.
 function isCertificateConfigured (environment) {
-  return CERTIFICATE_ENVS.some(name => Boolean(environment[name]))
+  return Boolean(
+    environment[PATH_ENV] ||
+    environment[PASSWORD_ENV] ||
+    normalizeFingerprint(environment[FINGERPRINT_ENV])
+  )
 }
 
 // `yarn make:win --arch <arch>` (see make.js) appends its trailing arguments to
@@ -22,6 +34,9 @@ function parseArguments (argv) {
       throw new Error(`[appx-signing] Unsupported argument: ${argv[index]}`)
     }
     index += 1
+    if (index >= argv.length) {
+      throw new Error('[appx-signing] --arch requires an architecture value.')
+    }
     args.push('--arch', validateBuildTarget(argv[index], 'win32').arch)
   }
   return args
@@ -44,6 +59,10 @@ function createAppxMakeInvocation ({ runtimePlatform, args = [] }) {
 }
 
 function main () {
+  // Validate arguments before the skip decision, so an unsupported argument
+  // fails the same way on a developer machine without a certificate as it
+  // does on the signing machine.
+  const forwardedArgs = parseArguments(process.argv.slice(2))
   const required = process.env[REQUIRE_ENV] === '1'
   if (!required && !isCertificateConfigured(process.env)) {
     console.log(`[appx-signing] No external APPX certificate configured; skipping make:appx (set ${REQUIRE_ENV}=1 to require it).`)
@@ -52,7 +71,7 @@ function main () {
 
   const invocation = createAppxMakeInvocation({
     runtimePlatform: process.platform,
-    args: parseArguments(process.argv.slice(2))
+    args: forwardedArgs
   })
   const result = spawnSync(invocation.command, invocation.args, {
     ...invocation.options,

--- a/build-scripts/windows/appx/make-appx-if-configured.js
+++ b/build-scripts/windows/appx/make-appx-if-configured.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const { spawnSync } = require('child_process')
+const { validateBuildTarget } = require('../../common/command-boundary')
+const { PATH_ENV, PASSWORD_ENV, FINGERPRINT_ENV } = require('./signing-certificate')
+
+const REQUIRE_ENV = 'ALPHABIZ_REQUIRE_APPX'
+const CERTIFICATE_ENVS = [PATH_ENV, PASSWORD_ENV, FINGERPRINT_ENV]
+
+function isCertificateConfigured (environment) {
+  return CERTIFICATE_ENVS.some(name => Boolean(environment[name]))
+}
+
+// `yarn make:win --arch <arch>` (see make.js) appends its trailing arguments to
+// the last command of the make:win chain, which is this script. Only a
+// validated `--arch` value is forwarded so the APPX target keeps the requested
+// architecture; anything else is rejected before it can reach cmd.exe.
+function parseArguments (argv) {
+  const args = []
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] !== '--arch') {
+      throw new Error(`[appx-signing] Unsupported argument: ${argv[index]}`)
+    }
+    index += 1
+    args.push('--arch', validateBuildTarget(argv[index], 'win32').arch)
+  }
+  return args
+}
+
+function createAppxMakeInvocation ({ runtimePlatform, args = [] }) {
+  if (runtimePlatform !== 'win32') {
+    return {
+      command: 'yarn',
+      args: ['make:appx', ...args],
+      options: { shell: false }
+    }
+  }
+
+  return {
+    command: 'C:\\Windows\\System32\\cmd.exe',
+    args: ['/d', '/s', '/c', 'yarn.cmd', 'make:appx', ...args],
+    options: { shell: false, windowsHide: true }
+  }
+}
+
+function main () {
+  const required = process.env[REQUIRE_ENV] === '1'
+  if (!required && !isCertificateConfigured(process.env)) {
+    console.log(`[appx-signing] No external APPX certificate configured; skipping make:appx (set ${REQUIRE_ENV}=1 to require it).`)
+    return 0
+  }
+
+  const invocation = createAppxMakeInvocation({
+    runtimePlatform: process.platform,
+    args: parseArguments(process.argv.slice(2))
+  })
+  const result = spawnSync(invocation.command, invocation.args, {
+    ...invocation.options,
+    stdio: 'inherit'
+  })
+  if (result.error) {
+    console.error(`[appx-signing] Failed to start Yarn: ${result.error.message}`)
+    return 1
+  }
+  if (result.status === null) {
+    console.error(`[appx-signing] make:appx was terminated by signal ${result.signal}.`)
+    return 1
+  }
+  return result.status
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main()
+  } catch (error) {
+    console.error(error.message)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  REQUIRE_ENV,
+  createAppxMakeInvocation,
+  isCertificateConfigured,
+  parseArguments
+}

--- a/build-scripts/windows/appx/signing-certificate.js
+++ b/build-scripts/windows/appx/signing-certificate.js
@@ -136,7 +136,7 @@ function getAppxSigningCertificate ({ required = false, expectedPublisher } = {}
     throw new Error(`[appx-signing] ${FINGERPRINT_ENV} must be a SHA-256 certificate fingerprint.`)
   }
   if (expectedFingerprint === RETIRED_FINGERPRINT) {
-    throw new Error('[appx-signing] The retired AlphaBiz development certificate is forbidden.')
+    throw new Error('[appx-signing] The retired Alphabiz development certificate is forbidden.')
   }
   if (!path.isAbsolute(configuredPath)) {
     throw new Error(`[appx-signing] ${PATH_ENV} must be an absolute path.`)
@@ -159,7 +159,7 @@ function getAppxSigningCertificate ({ required = false, expectedPublisher } = {}
   const metadata = readCertificateMetadata(certificatePath, password)
   const actualFingerprint = metadata.fingerprint
   if (actualFingerprint === RETIRED_FINGERPRINT) {
-    throw new Error('[appx-signing] The retired AlphaBiz development certificate is forbidden.')
+    throw new Error('[appx-signing] The retired Alphabiz development certificate is forbidden.')
   }
   if (actualFingerprint !== expectedFingerprint) {
     throw new Error('[appx-signing] The certificate fingerprint does not match the approved fingerprint.')

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:release:creditsUpload": "jest test/jest/release/creditsUpload.spec.js --c=./test/jest/release/jest.config.js",
     "test:release:creditsDownload": "jest test/jest/release/creditsDownload.spec.js --c=./test/jest/release/jest.config.js",
     "make": "node build-scripts/common/make.js --make",
-    "make:win": "yarn make:squirrel && yarn make:msi && yarn make:appx",
+    "make:win": "yarn make:squirrel && yarn make:msi && node build-scripts/windows/appx/make-appx-if-configured.js",
     "make:squirrel": "yarn pkg-fmt -f exe && electron-forge make --skip-package --targets @electron-forge/maker-squirrel",
     "make:appx": "node build-scripts/windows/appx/signing-certificate.js && yarn pkg-fmt -f appx && electron-forge make --skip-package --targets @electron-forge/maker-appx",
     "make:msi": "yarn pkg-fmt -f msi && node ./build-scripts/windows/wix/make.js",

--- a/scripts/security/test-appx-signing.js
+++ b/scripts/security/test-appx-signing.js
@@ -45,6 +45,15 @@ try {
     new RegExp(PATH_ENV)
   )
 
+  const makeScriptSource = fs.readFileSync(
+    path.resolve(__dirname, '../../build-scripts/common/make.js'),
+    'utf-8'
+  )
+  assert(
+    makeScriptSource.includes('ALPHABIZ_REQUIRE_APPX'),
+    'make.js must keep the ALPHABIZ_REQUIRE_APPX opt-in for the APPX certificate requirement'
+  )
+
   if (process.argv.includes('--forge-config')) {
     const unsignedConfig = loadForgeConfig()
     assert.strictEqual(

--- a/scripts/security/test-appx-signing.js
+++ b/scripts/security/test-appx-signing.js
@@ -15,6 +15,11 @@ const {
   getAppxSigningCertificate,
   readCertificateFingerprint
 } = require('../../build-scripts/windows/appx/signing-certificate')
+const {
+  createAppxMakeInvocation,
+  isCertificateConfigured,
+  parseArguments
+} = require('../../build-scripts/windows/appx/make-appx-if-configured')
 
 const environmentNames = [PATH_ENV, PASSWORD_ENV, FINGERPRINT_ENV]
 const originalEnvironment = Object.fromEntries(
@@ -53,6 +58,46 @@ try {
     makeScriptSource.includes('ALPHABIZ_REQUIRE_APPX'),
     'make.js must keep the ALPHABIZ_REQUIRE_APPX opt-in for the APPX certificate requirement'
   )
+
+  // The make:win chain ends in make-appx-if-configured.js, which builds a
+  // command line from process.argv. Lock its boundary the way
+  // test-codeql-hardening.js locks createYarnInvocation.
+  assert.deepStrictEqual(
+    createAppxMakeInvocation({ runtimePlatform: 'win32', args: ['--arch', 'x64'] }),
+    {
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'yarn.cmd', 'make:appx', '--arch', 'x64'],
+      options: { shell: false, windowsHide: true }
+    }
+  )
+  assert.deepStrictEqual(
+    createAppxMakeInvocation({ runtimePlatform: 'linux' }),
+    {
+      command: 'yarn',
+      args: ['make:appx'],
+      options: { shell: false }
+    }
+  )
+  assert.deepStrictEqual(parseArguments([]), [])
+  assert.deepStrictEqual(parseArguments(['--arch', 'x64']), ['--arch', 'x64'])
+  assert.throws(
+    () => parseArguments(['--inspect']),
+    /Unsupported argument/
+  )
+  assert.throws(
+    () => parseArguments(['--arch', 'x64;touch-pwned']),
+    /Unsupported BUILD_ARCH/
+  )
+  assert.throws(
+    () => parseArguments(['--arch']),
+    /--arch requires an architecture value/
+  )
+
+  // The skip decision must agree with getAppxSigningCertificate: a
+  // fingerprint with no hex digits counts as unconfigured for both.
+  assert.strictEqual(isCertificateConfigured({}), false)
+  assert.strictEqual(isCertificateConfigured({ [FINGERPRINT_ENV]: 'xxx' }), false)
+  assert.strictEqual(isCertificateConfigured({ [PATH_ENV]: '/tmp/cert.pfx' }), true)
 
   if (process.argv.includes('--forge-config')) {
     const unsignedConfig = loadForgeConfig()

--- a/scripts/security/test-appx-signing.js
+++ b/scripts/security/test-appx-signing.js
@@ -150,7 +150,7 @@ try {
   process.env[FINGERPRINT_ENV] = RETIRED_FINGERPRINT
   assert.throws(
     () => getAppxSigningCertificate({ required: true }),
-    /retired AlphaBiz development certificate/
+    /retired Alphabiz development certificate/
   )
 
   process.env[FINGERPRINT_ENV] = fingerprint


### PR DESCRIPTION
## Summary

Since #38 retired the tracked development certificate, plain `yarn make` on Windows aborted before building anything unless the `ALPHABIZ_APPX_*` variables were set, because `build-scripts/common/make.js` demanded the certificate unconditionally (`forge.config.js` already degraded gracefully). This PR makes the APPX certificate opt-in for `yarn make` / `yarn make:win`, so an unsigned EXE + MSI build works out of the box again, and adds two small guards to the packager configuration.

## What changed

- `build-scripts/common/make.js` — the certificate is required only when `ALPHABIZ_REQUIRE_APPX=1`; otherwise a message explains that APPX is skipped. Partial configuration still fails closed (unchanged helper semantics).
- `package.json` — `make:win` runs squirrel, then msi, then `build-scripts/windows/appx/make-appx-if-configured.js`.
- `build-scripts/windows/appx/make-appx-if-configured.js` (new) — skips with exit 0 when no certificate variable is set and `ALPHABIZ_REQUIRE_APPX` is not `1`; otherwise runs `yarn make:appx` with the same shell-free invocation shape as `command-boundary.js` and propagates the exit status.
- `build-scripts/common/electron-packager.js` — clear error when `public/version.json` is missing (run `yarn unpackaged` first); the velectron downloader is required lazily so loading the configuration has no side effects.
- `scripts/security/test-appx-signing.js` — asserts the opt-in flag is present in `make.js`.

## Verification

| Check | Result |
| --- | --- |
| `node build-scripts/windows/appx/make-appx-if-configured.js` (no certificate) | prints the skip message, exit 0 |
| same with `ALPHABIZ_REQUIRE_APPX=1` | exit 1 (fail-closed) |
| same with a trailing `--arch` | `[appx-signing] --arch requires an architecture value.`, exit 1 |
| unsupported argument on the skip path | rejected, exit 1 (previously ignored) |
| `ALPHABIZ_APPX_CERT_SHA256=xxx` | `getAppxSigningCertificate({required:false})` and `isCertificateConfigured` now agree (both "not configured") |
| `require('./build-scripts/common/electron-packager.js')` | fails only with the new message, naming the path actually probed |
| `yarn security:test-appx`, `test-appx:forge`, `test-codeql`, `test-scan`, `scan-credentials` | all pass |
| `git diff main..HEAD --name-only` | six files, no dependency on the other pull requests |

Not verifiable on the machine that produced this PR (macOS): the Windows `yarn make:win` path itself. The change is confined to the certificate gate and the invocation of an existing script.

## Compatibility and rollback

Release builds that must produce an APPX should set `ALPHABIZ_REQUIRE_APPX=1` together with the `ALPHABIZ_APPX_*` variables. `git revert -m 1 <merge-sha>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
