### PR TITLE
docs: drop the horizontal rule left at the end of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,4 +155,3 @@ Please report vulnerabilities through [private vulnerability reporting](https://
 
 Alphabiz is free software under the [GNU General Public License v2](LICENSE). Licensing or source questions: <ab@alpha.biz>.
 
----


### PR DESCRIPTION
Follow-up to 7ede51a7, which removed the Chinese footer and left the `---` above it dangling as the last line of the README. This removes the rule; no other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)